### PR TITLE
Advanced plan updates

### DIFF
--- a/Cloudinary.Test/CloudinaryTest.cs
+++ b/Cloudinary.Test/CloudinaryTest.cs
@@ -1085,8 +1085,10 @@ namespace CloudinaryDotNet.Test
         {
             var result = m_cloudinary.GetUsage();
 
+            var plans = new List<string>() { "Free", "Advanced" };
+
             Assert.NotNull(result);
-            Assert.AreEqual("Free", result.Plan);
+            Assert.True(plans.Contains(result.Plan));
             Assert.True(result.Resources > 0);
             Assert.True(result.Objects.Used < result.Objects.Limit);
             Assert.True(result.Bandwidth.Used < result.Bandwidth.Limit);

--- a/Cloudinary/Actions/UsageResult.cs
+++ b/Cloudinary/Actions/UsageResult.cs
@@ -46,10 +46,10 @@ namespace CloudinaryDotNet.Actions
     public class Usage
     {
         [DataMember(Name = "usage")]
-        public int Used { get; protected set; }
+        public long Used { get; protected set; }
 
         [DataMember(Name = "limit")]
-        public int Limit { get; protected set; }
+        public long Limit { get; protected set; }
 
         [DataMember(Name = "used_percent")]
         public float UsedPercent { get; protected set; }


### PR DESCRIPTION
TestUsage correctly executes for 'Advanced' plans
Usage int data types swapped to long to cater for advanced plan sizes
