### PR TITLE
Turn off AllowWriteStreamBuffering to prevent data buffering in memory

### DIFF
--- a/Cloudinary/Api.cs
+++ b/Cloudinary/Api.cs
@@ -317,6 +317,8 @@ namespace CloudinaryDotNet
 
             if (method == HttpMethod.POST && parameters != null)
             {
+                request.AllowWriteStreamBuffering = false;
+                request.AllowAutoRedirect = false;
                 if (UseChunkedEncoding)
                     request.SendChunked = true;
 


### PR DESCRIPTION
While doing some integration tests we discovered that memory consumption after uploading several large files grew. After tracing the problem we discovered that this is caused due to AllowWriteStreamBuffering (more info here: https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.allowwritestreambuffering%28v=vs.110%29.aspx). 

In a test case we uploaded 5 files 4 MB each approx, before the test started the memory consumption was as follows
![1](https://cloud.githubusercontent.com/assets/5121063/12977886/d6cbb752-d0cd-11e5-943f-fed159d8c582.png)
After the upload was finished memory footprint grew around 20 MB
![2](https://cloud.githubusercontent.com/assets/5121063/12977895/e8b2517e-d0cd-11e5-89b3-3a1826780985.png)

When turning off WriteStreamBuffering we can see that no longer memory grows, initial state of the test process
![3](https://cloud.githubusercontent.com/assets/5121063/12977921/0fe1de22-d0ce-11e5-9c24-93fb80fb93ab.png)
After uploading the same images
![4](https://cloud.githubusercontent.com/assets/5121063/12977929/1a18f812-d0ce-11e5-80c8-613193bc38ce.png)


