### PR TITLE
Allow Rename and Tag update calls to specify a ResourceType

### DIFF
--- a/Cloudinary/Cloudinary.cs
+++ b/Cloudinary/Cloudinary.cs
@@ -382,7 +382,8 @@ namespace CloudinaryDotNet
         /// <returns></returns>
         public RenameResult Rename(RenameParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("rename").BuildUrl();
+            string uri = m_api.ApiUrlV.ResourceType(
+                Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).Action("rename").BuildUrl();
 
             using (HttpWebResponse response =m_api.Call(HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {
@@ -441,7 +442,8 @@ namespace CloudinaryDotNet
         /// <returns>Results of tags management</returns>
         public TagResult Tag(TagParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("tags").BuildUrl();
+            string uri = m_api.ApiUrlV.ResourceType(
+                Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).Action("tags").BuildUrl();
 
             using (HttpWebResponse response =m_api.Call(HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
@@ -9,6 +9,7 @@ namespace CloudinaryDotNet.Actions
         {
             FromPublicId = fromPublicId;
             ToPublicId = toPublicId;
+            ResourceType = ResourceType.Image;
         }
 
         /// <summary>
@@ -44,6 +45,11 @@ namespace CloudinaryDotNet.Actions
         ///   <c>true</c> to invalidate; otherwise, <c>false</c>.
         /// </value>
         public bool Invalidate { get; set; }
+
+        /// <summary>
+        /// The type of resource to rename
+        /// </summary>
+        public ResourceType ResourceType { get; set; }
 
         /// <summary>
         /// Maps object model to dictionary of parameters in cloudinary notation

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
@@ -10,6 +10,11 @@ namespace CloudinaryDotNet.Actions
     /// </summary>
     public class TagParams : BaseParams
     {
+        public TagParams()
+        {
+            ResourceType = ResourceType.Image;
+        }
+
         List<string> m_publicIds = new List<string>();
 
         /// <summary>
@@ -35,6 +40,11 @@ namespace CloudinaryDotNet.Actions
         /// The action to perform on image resources using the given tag.
         /// </summary>
         public TagCommand Command { get; set; }
+
+        /// <summary>
+        /// The type of resource to change tags on
+        /// </summary>
+        public ResourceType ResourceType { get; set; }
 
         /// <summary>
         /// Validate object model

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Cloudinary.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Cloudinary.cs
@@ -363,7 +363,8 @@ namespace CloudinaryDotNet
         /// <returns></returns>
         public RenameResult Rename(RenameParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("rename").BuildUrl();
+            string uri = m_api.ApiUrlV.ResourceType(
+                Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).Action("rename").BuildUrl();
 
             using (HttpResponseMessage response =m_api.Call(CloudinaryShared.Core.HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {
@@ -422,7 +423,8 @@ namespace CloudinaryDotNet
         /// <returns>Results of tags management</returns>
         public TagResult Tag(TagParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("tags").BuildUrl();
+            string uri = m_api.ApiUrlV.ResourceType(
+                Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).Action("tags").BuildUrl();
 
             using (HttpResponseMessage response =m_api.Call(CloudinaryShared.Core.HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {


### PR DESCRIPTION
The `Rename()` and `Tag()` api calls were locked to `ResourceType.Image` (since they were using `ApiUrlImgUpV`).

I've added a new `ResourceType` parameter to their respective Params classes (used same code as is already used in `DeletionParams`), defaulted to `ResourceType.Image` for backwards compatibility.
The `ResourceType` parameter is then used when creating the API call for Rename/Tag action.

_Hope I've submitted this correctly - I've been using Git for a while, but this is my first attempt at a pull request :)_