### PR TITLE
Added support for different resource_types in Rename and Tag

### DIFF
--- a/Cloudinary/Cloudinary.cs
+++ b/Cloudinary/Cloudinary.cs
@@ -382,8 +382,9 @@ namespace CloudinaryDotNet
         /// <returns></returns>
         public RenameResult Rename(RenameParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("rename").BuildUrl();
-
+            string uri = m_api.ApiUrlImgUpV.ResourceType(
+				Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).
+				Action("rename").BuildUrl();
             using (HttpWebResponse response =m_api.Call(HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {
                 return RenameResult.Parse(response);
@@ -441,7 +442,9 @@ namespace CloudinaryDotNet
         /// <returns>Results of tags management</returns>
         public TagResult Tag(TagParams parameters)
         {
-            string uri = m_api.ApiUrlImgUpV.Action("tags").BuildUrl();
+            string uri = m_api.ApiUrlImgUpV.ResourceType(
+				Api.GetCloudinaryParam<ResourceType>(parameters.ResourceType)).
+				Action("tags").BuildUrl();
 
             using (HttpWebResponse response =m_api.Call(HttpMethod.POST, uri, parameters.ToParamsDictionary(), null))
             {

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
@@ -27,6 +27,11 @@ namespace CloudinaryDotNet.Actions
         /// </value>
         public string ToPublicId { get; set; }
 
+		/// <summary>
+		/// The type of resource to rename
+		/// </summary>
+		public ResourceType ResourceType { get; set; }
+
         public string Type { get; set; }
 
         /// <summary>

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/RenameParams.cs
@@ -9,6 +9,7 @@ namespace CloudinaryDotNet.Actions
         {
             FromPublicId = fromPublicId;
             ToPublicId = toPublicId;
+			ResourceType = ResourceType.Image;
         }
 
         /// <summary>

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
@@ -26,6 +26,11 @@ namespace CloudinaryDotNet.Actions
         /// </summary>
         public string Tag { get; set; }
 
+		/// <summary>
+		/// The type of resource to tag
+		/// </summary>
+		public ResourceType ResourceType { get; set; }
+
         /// <summary>
         /// Type
         /// </summary>

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/Actions/TagParams.cs
@@ -10,6 +10,12 @@ namespace CloudinaryDotNet.Actions
     /// </summary>
     public class TagParams : BaseParams
     {
+
+		public TagParams()
+		{
+			ResourceType = ResourceType.Image;
+		}
+
         List<string> m_publicIds = new List<string>();
 
         /// <summary>

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/ApiShared.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/ApiShared.cs
@@ -325,8 +325,9 @@ namespace CloudinaryShared.Core
         /// <returns>Signature of parameters</returns>
         public string SignParameters(IDictionary<string, object> parameters)
         {
+			List<string> excludedSignatureKeys = new List<string>(new string[] { "resource_type", "file", "type","api_key" });
             StringBuilder signBase = new StringBuilder(String.Join("&", parameters
-                .Where(pair => pair.Value != null)
+			                                                       .Where(pair => pair.Value != null && !excludedSignatureKeys.Any(s => pair.Key.Contains(s)))
                 .Select(pair => String.Format("{0}={1}", pair.Key,
                     pair.Value is IEnumerable<string>
                     ? String.Join(",", ((IEnumerable<string>)pair.Value).ToArray())

--- a/Cloudinary/Shared/Coudinary.NetCoreShared/ApiShared.cs
+++ b/Cloudinary/Shared/Coudinary.NetCoreShared/ApiShared.cs
@@ -326,8 +326,8 @@ namespace CloudinaryShared.Core
         public string SignParameters(IDictionary<string, object> parameters)
         {
 			List<string> excludedSignatureKeys = new List<string>(new string[] { "resource_type", "file", "type","api_key" });
-            StringBuilder signBase = new StringBuilder(String.Join("&", parameters
-			                                                       .Where(pair => pair.Value != null && !excludedSignatureKeys.Any(s => pair.Key.Contains(s)))
+            StringBuilder signBase = new StringBuilder(String.Join("&", parameters.
+			                                                       Where(pair => pair.Value != null && !excludedSignatureKeys.Any(s => pair.Key.Equals(s)))
                 .Select(pair => String.Format("{0}={1}", pair.Key,
                     pair.Value is IEnumerable<string>
                     ? String.Join(",", ((IEnumerable<string>)pair.Value).ToArray())


### PR DESCRIPTION
Rename and Tag can now support different resource_types.

In addition, added a condition to exclude certain parameters from the signature (params listed [here](http://cloudinary.com/documentation/upload_images#creating_api_authentication_signatures)).
Useful when adding these parameters by AddCustomParam(). 