### PR TITLE
Fix `SignParameters()`

### DIFF
--- a/Shared.Tests/ApiTest.cs
+++ b/Shared.Tests/ApiTest.cs
@@ -1325,14 +1325,13 @@ namespace CloudinaryDotNet.Test
 
             Dictionary<string, object> paramsSetTwo = new Dictionary<string, object>(paramsSetOne) {
                 { "resource_type", "image" },
+                { "type", "anyType" },
                 { "file", "anyFile" },
                 { "api_key", "343dsfdf033e-23zx" }
             };
 
             StringAssert.AreEqualIgnoringCase(m_api.SignParameters(paramsSetOne), m_api.SignParameters(paramsSetTwo), "The signatures are not equal.");
-
             paramsSetTwo.Add("Param4", "test");
-
             StringAssert.AreNotEqualIgnoringCase(m_api.SignParameters(paramsSetOne), m_api.SignParameters(paramsSetTwo), "The signatures are equal.");
         }
     }

--- a/Shared/ApiShared.cs
+++ b/Shared/ApiShared.cs
@@ -350,7 +350,7 @@ namespace CloudinaryDotNet
         /// <returns>Signature of parameters</returns>
         public string SignParameters(IDictionary<string, object> parameters)
         {
-			List<string> excludedSignatureKeys = new List<string>(new string[] { "resource_type", "file", "api_key" });
+			List<string> excludedSignatureKeys = new List<string>(new string[] { "resource_type", "file", "type", "api_key" });
             StringBuilder signBase = new StringBuilder(String.Join("&", parameters.
 			                                                       Where(pair => pair.Value != null && !excludedSignatureKeys.Any(s => pair.Key.Equals(s)))
                 .Select(pair => String.Format("{0}={1}", pair.Key,


### PR DESCRIPTION
An addition to #94 (previously #78). Adds `type` to excluded params as documentation states https://cloudinary.com/documentation/upload_images#creating_api_authentication_signatures 