### PR TITLE
Address some issues with NuGet package creation.

### DIFF
--- a/CloudinaryDotNet.nuspec
+++ b/CloudinaryDotNet.nuspec
@@ -15,10 +15,17 @@
     <copyright>Copyright 2017</copyright>
     <tags>Image Video Responsive Web Utility CDN Performance Resize Crop Rotate Quality Watermark Gif Jpg Jpeg Bitmap PNG Tiff Webp Webm mp4 avi Filter Effect</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="12.0.1" />
+      <group targetFramework="net45">
+        <dependency id="Newtonsoft.Json" version="12.0.1" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Text.Encodings.Web" version="4.5.0" />
+      </group>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Newtonsoft.Json" version="12.0.1" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="lib\**" target="lib" />
+    <file src="lib\**\Cloudinary*.*" exclude="lib\**\Cloudinary*.deps.json" target="lib" />
   </files>
  </package>

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,6 @@ $libPath = "lib"
 $targetFrameworks = @{
  "\net45" = $netClassicPath;
  "\netstandard1.3" = $netCorePath;
- "\netcore" = $netCorePath;
 }
 
 


### PR DESCRIPTION
The current nuget package lists `Newtonsoft.Json` as a dependency, but also ships `Newtonsoft.Json.dll` as part of the package. This results in situations where .Net Framework projects with an existing reference to `Newtonsoft.Json` the project reference path gets highjacked when installing the `CloudinaryDotNet` package.

Here is a screenshot of what I am referring to:
![image](https://user-images.githubusercontent.com/632589/75580027-3ef83d80-5a24-11ea-9ecd-8cdd474353a9.png)

This PR addresses this by not shipping the `Newtonsoft.Json` assembly as part of the package and allows NuGet to handle the dependency.

Additionally, there is a `netcore` folder that is shipped as part of the existing `CloudinaryDotNet` package. This is problematic due to the following two reasons:

1. `netcore` isn't a valid target framework moniker
2. The `CloudinaryDotNet.Core.csproj` project only defines `netstandard1.3` as the `TargetFramework` https://github.com/cloudinary/CloudinaryDotNet/blob/0f4e796c864771877fcab87449309cdbcb20eab6/Core/CloudinaryDotNet.Core.csproj#L3

Due to item 2 listed above, the assembly in the `netcore` folder is actually a `netstandard1.3` assembly.
