### PR TITLE
Add support for `ListResourcesByAssetFolder` Admin API

### DIFF
--- a/CloudinaryDotNet.IntegrationTests/AdminApi/BrowseResourcesTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/AdminApi/BrowseResourcesTest.cs
@@ -340,6 +340,42 @@ namespace CloudinaryDotNet.IntegrationTests.AdminApi
         }
 
         [Test, RetryWithDelay]
+        public void TestListResourcesByAssetFolder()
+        {
+            var publicId1 = GetUniquePublicId();
+            var publicId2 = GetUniquePublicId();
+
+            var assetFolder = GetUniqueFolder();
+
+            var uploadParams = new ImageUploadParams()
+            {
+                File = new FileDescription(m_testImagePath),
+                PublicId = publicId1,
+                AssetFolder = assetFolder,
+                Tags = m_apiTag
+            };
+
+            m_cloudinary.Upload(uploadParams);
+
+            uploadParams = new ImageUploadParams()
+            {
+                File = new FileDescription(m_testImagePath),
+                PublicId = publicId2,
+                AssetFolder = assetFolder,
+                Tags = m_apiTag
+            };
+
+            m_cloudinary.Upload(uploadParams);
+
+            var result = m_cloudinary.ListResourcesByAssetFolder(assetFolder);
+
+            Assert.AreEqual(2, result.Resources.Length);
+
+            Assert.AreEqual(publicId1, result.Resources[1].PublicId);
+            Assert.AreEqual(publicId2, result.Resources[0].PublicId);
+        }
+
+        [Test, RetryWithDelay]
         public void TestListResourcesByTag()
         {
             // should allow listing resources by tag

--- a/CloudinaryDotNet.IntegrationTests/AdminApi/BrowseResourcesTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/AdminApi/BrowseResourcesTest.cs
@@ -339,7 +339,7 @@ namespace CloudinaryDotNet.IntegrationTests.AdminApi
             Assert.AreEqual(publicId2, result.Resources[1].PublicId);
         }
 
-        [Test, RetryWithDelay]
+        [Test, IgnoreFeature("dynamic_folders"), RetryWithDelay]
         public void TestListResourcesByAssetFolder()
         {
             var publicId1 = GetUniquePublicId();

--- a/CloudinaryDotNet.IntegrationTests/AdminApi/UpdateResourcesTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/AdminApi/UpdateResourcesTest.cs
@@ -268,7 +268,7 @@ namespace CloudinaryDotNet.IntegrationTests.AdminApi
             Assert.AreEqual(ModerationStatus.Approved, updateResult.Moderation[0].Status);
         }
 
-        [Test, RetryWithDelay]
+        [Test, IgnoreFeature("dynamic_folders"), RetryWithDelay]
         public void TestUpdateDynamicFolderAttributes()
         {
             //should update quality

--- a/CloudinaryDotNet.IntegrationTests/AdminApi/UpdateResourcesTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/AdminApi/UpdateResourcesTest.cs
@@ -269,6 +269,37 @@ namespace CloudinaryDotNet.IntegrationTests.AdminApi
         }
 
         [Test, RetryWithDelay]
+        public void TestUpdateDynamicFolderAttributes()
+        {
+            //should update quality
+            var publicId = GetUniquePublicId();
+            var assetFolder = GetUniqueFolder();
+            var displayName = GetUniquePublicId();
+            var upResult = m_cloudinary.Upload(new ImageUploadParams
+                {
+                    File = new FileDescription(m_testImagePath),
+                    PublicId = publicId,
+                    Tags = m_apiTag
+                }
+            );
+
+            var updResult = m_cloudinary.UpdateResource(
+                new UpdateParams(upResult.PublicId)
+                {
+                    AssetFolder = assetFolder,
+                    DisplayName = displayName,
+                    UniqueDisplayName = true
+
+                });
+            Assert.AreEqual(updResult.StatusCode, HttpStatusCode.OK, updResult.Error?.Message);
+            Assert.Null(updResult.Error);
+
+            Assert.AreEqual(updResult.PublicId, publicId);
+            Assert.AreEqual(assetFolder, updResult.AssetFolder);
+            Assert.AreEqual(displayName, updResult.DisplayName);
+        }
+
+        [Test, RetryWithDelay]
         public void TestUpdateResourceMetadata()
         {
             var uploadResult = m_cloudinary.Upload(new ImageUploadParams

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/RenameMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/RenameMethodsTest.cs
@@ -118,7 +118,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             Assert.IsNull(renameResult.MetadataFields);
         }
 
-        [Test]
+        [Test, IgnoreFeature("dynamic_folders")]
         public async Task TestRenameWithDynamicFolderAttributesInResult()
         {
             var publicId = GetUniquePublicId();

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/RenameMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/RenameMethodsTest.cs
@@ -118,6 +118,21 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             Assert.IsNull(renameResult.MetadataFields);
         }
 
+        [Test]
+        public async Task TestRenameWithDynamicFolderAttributesInResult()
+        {
+            var publicId = GetUniquePublicId();
+            var newPublicId = GetUniquePublicId();
+
+            await UploadImage(publicId);
+
+            var @params = new RenameParams(publicId, newPublicId);
+            var renameResult =  m_cloudinary.Rename(@params);
+
+            Assert.NotNull(renameResult.AssetFolder);
+            Assert.NotNull(renameResult.DisplayName);
+        }
+
         private async Task UploadImage(string publicId, bool withMetadata = false)
         {
             if (withMetadata)

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -893,8 +893,11 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             {
                 File = new FileDescription(m_testImagePath),
                 CustomCoordinates = coordinates,
-                Tags = m_apiTag
+                Tags = m_apiTag,
+                DisplayName = GetUniquePublicId()
             });
+
+            Assert.IsNotEmpty(upResult.DisplayName);
 
             var result = m_cloudinary.GetResource(new GetResourceParams(upResult.PublicId)
             {
@@ -909,6 +912,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
 
             Assert.NotNull(result.NextCursor, result.Error?.Message);
             Assert.NotZero(result.Tags.Length);
+            Assert.IsNotEmpty(result.DisplayName);
         }
 
         [Test, RetryWithDelay]

--- a/CloudinaryDotNet.Tests/Parameters/ParametersTest.cs
+++ b/CloudinaryDotNet.Tests/Parameters/ParametersTest.cs
@@ -184,6 +184,7 @@ namespace CloudinaryDotNet.Tests.Parameters
                 DisplayName = "test",
                 UseFilenameAsDisplayName = true,
                 AssetFolder = "asset_folder",
+                UseAssetFolderAsPublicIdPrefix = true,
                 Folder = "folder"
             };
 
@@ -194,6 +195,7 @@ namespace CloudinaryDotNet.Tests.Parameters
             Assert.AreEqual("test", dictionary["display_name"]);
             Assert.AreEqual("true", dictionary["use_filename_as_display_name"]);
             Assert.AreEqual("asset_folder", dictionary["asset_folder"]);
+            Assert.AreEqual("true", dictionary["use_asset_folder_as_public_id_prefix"]);
             Assert.AreEqual("folder", dictionary["folder"]);
         }
 
@@ -205,7 +207,8 @@ namespace CloudinaryDotNet.Tests.Parameters
                 PublicIdPrefix = "fd_public_id_prefix",
                 DisplayName = "test",
                 UseFilenameAsDisplayName = true,
-                AssetFolder = "asset_folder"
+                AssetFolder = "asset_folder",
+                UseAssetFolderAsPublicIdPrefix = true,
             };
 
             var dictionary = parameters.ToParamsDictionary();
@@ -214,6 +217,7 @@ namespace CloudinaryDotNet.Tests.Parameters
             Assert.AreEqual("test", dictionary["display_name"]);
             Assert.AreEqual("true", dictionary["use_filename_as_display_name"]);
             Assert.AreEqual("asset_folder", dictionary["asset_folder"]);
+            Assert.AreEqual("true", dictionary["use_asset_folder_as_public_id_prefix"]);
         }
 
         [Test]

--- a/CloudinaryDotNet/Actions/AssetsManagement/GetResourceResult.cs
+++ b/CloudinaryDotNet/Actions/AssetsManagement/GetResourceResult.cs
@@ -261,6 +261,18 @@
         public string AssetId { get; set; }
 
         /// <summary>
+        /// Gets or sets asset folder.
+        /// </summary>
+        [DataMember(Name = "asset_folder")]
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets asset display name.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
         /// Gets or sets list of asset versions.
         /// </summary>
         [DataMember(Name = "versions")]

--- a/CloudinaryDotNet/Actions/AssetsManagement/ListResourcesByAssetFolderParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsManagement/ListResourcesByAssetFolderParams.cs
@@ -1,0 +1,48 @@
+﻿namespace CloudinaryDotNet.Actions
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows to filter resources by asset folder.
+    /// </summary>
+    public class ListResourcesByAssetFolderParams : ListResourcesParams
+    {
+        /// <summary>
+        /// Gets or sets the asset folder to filter resources.
+        /// </summary>
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Validate object model.
+        /// </summary>
+        /// <exception cref="System.ArgumentException">Tag must be set to list resource by tag.</exception>
+        public override void Check()
+        {
+            base.Check();
+
+            if (string.IsNullOrEmpty(AssetFolder))
+            {
+                throw new ArgumentException("AssetFolder must be set to filter resources by AssetFolder!");
+            }
+        }
+
+        /// <summary>
+        /// Maps object model to dictionary of parameters in cloudinary notation.
+        /// </summary>
+        /// <returns>Sorted dictionary of parameters.</returns>
+        public override SortedDictionary<string, object> ToParamsDictionary()
+        {
+            SortedDictionary<string, object> dict = base.ToParamsDictionary();
+
+            if (dict.ContainsKey("type"))
+            {
+                dict.Remove("type");
+            }
+
+            AddParam(dict, "asset_folder", AssetFolder);
+
+            return dict;
+        }
+    }
+}

--- a/CloudinaryDotNet/Actions/AssetsManagement/UpdateParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsManagement/UpdateParams.cs
@@ -28,6 +28,25 @@
         public string PublicId { get; set; }
 
         /// <summary>
+        /// Gets or sets the folder where the asset is stored in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name that is displayed for the asset in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to make sure that display name is unique.
+        /// When set to false, should not add random characters at the end of the display name to guarantee its uniqueness.
+        /// Only relevant if <see cref="DisplayName"/> or <see cref="AssetFolder"/> are provided.
+        /// </summary>
+        public bool UniqueDisplayName { get; set; }
+
+        /// <summary>
         /// Gets or sets the type of file. Possible values: image, raw, video. Default: image.
         /// </summary>
         public ResourceType ResourceType { get; set; }
@@ -172,6 +191,9 @@
             SortedDictionary<string, object> dict = base.ToParamsDictionary();
 
             AddParam(dict, "public_id", PublicId);
+            AddParam(dict, "asset_folder", AssetFolder);
+            AddParam(dict, "display_name", DisplayName);
+            AddParam(dict, "unique_display_name", UniqueDisplayName);
             AddParam(dict, "tags", Tags);
             AddParam(dict, "type", Type);
             AddParam(dict, "categorization", Categorization);

--- a/CloudinaryDotNet/Actions/AssetsUpload/ExplicitParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/ExplicitParams.cs
@@ -110,7 +110,7 @@ namespace CloudinaryDotNet.Actions
         /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
         /// to a folder in the Media Library) as a prefix to the public_id value.
         /// </summary>
-        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+        public bool? UseAssetFolderAsPublicIdPrefix { get; set; }
 
         /// <summary>
         /// Gets or sets the coordinates of faces contained in an uploaded image and overrides the automatically detected

--- a/CloudinaryDotNet/Actions/AssetsUpload/ExplicitParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/ExplicitParams.cs
@@ -106,6 +106,13 @@ namespace CloudinaryDotNet.Actions
         public string AssetFolder { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether gets or sets whether to automatically apply the path specified
+        /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
+        /// to a folder in the Media Library) as a prefix to the public_id value.
+        /// </summary>
+        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+
+        /// <summary>
         /// Gets or sets the coordinates of faces contained in an uploaded image and overrides the automatically detected
         /// faces.
         /// Use plain string (x,y,w,h|x,y,w,h) or <see cref="Core.Rectangle"/>.
@@ -276,6 +283,7 @@ namespace CloudinaryDotNet.Actions
             AddParam(dict, "display_name", DisplayName);
             AddParam(dict, "use_filename_as_display_name", UseFilenameAsDisplayName);
             AddParam(dict, "asset_folder", AssetFolder);
+            AddParam(dict, "use_asset_folder_as_public_id_prefix", UseAssetFolderAsPublicIdPrefix);
 
             if (ResourceType == ResourceType.Image)
             {

--- a/CloudinaryDotNet/Actions/AssetsUpload/RawUploadParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/RawUploadParams.cs
@@ -104,6 +104,13 @@
         public string AssetFolder { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether gets or sets whether to automatically apply the path specified
+        /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
+        /// to a folder in the Media Library) as a prefix to the public_id value.
+        /// </summary>
+        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+
+        /// <summary>
         /// Gets or sets whether to overwrite existing resources with the same public ID.
         /// </summary>
         public bool? Overwrite { get; set; }
@@ -182,6 +189,7 @@
             AddParam(dict, "proxy", Proxy);
             AddParam(dict, "folder", Folder);
             AddParam(dict, "asset_folder", AssetFolder);
+            AddParam(dict, "use_asset_folder_as_public_id_prefix", UseAssetFolderAsPublicIdPrefix);
             AddParam(dict, "raw_convert", RawConvert);
             AddParam(dict, "overwrite", Overwrite);
             AddParam(dict, "async", Async);

--- a/CloudinaryDotNet/Actions/AssetsUpload/RawUploadParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/RawUploadParams.cs
@@ -108,7 +108,7 @@
         /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
         /// to a folder in the Media Library) as a prefix to the public_id value.
         /// </summary>
-        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+        public bool? UseAssetFolderAsPublicIdPrefix { get; set; }
 
         /// <summary>
         /// Gets or sets whether to overwrite existing resources with the same public ID.

--- a/CloudinaryDotNet/Actions/AssetsUpload/UploadResult.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/UploadResult.cs
@@ -23,6 +23,20 @@
         public string PublicId { get; set; }
 
         /// <summary>
+        /// Gets or sets the folder where the asset is stored in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        [DataMember(Name = "asset_folder")]
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name that is displayed for the asset in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
         /// Gets or sets version of uploaded asset.
         /// </summary>
         [DataMember(Name = "version")]

--- a/CloudinaryDotNet/Actions/PresetsUpload/UploadPresetParams.cs
+++ b/CloudinaryDotNet/Actions/PresetsUpload/UploadPresetParams.cs
@@ -58,6 +58,7 @@
             NotificationUrl = preset.Settings.NotificationUrl;
             Proxy = preset.Settings.Proxy;
             Folder = preset.Settings.Folder;
+            UseAssetFolderAsPublicIdPrefix = preset.Settings.UseAssetFolderAsPublicIdPrefix;
             Overwrite = preset.Settings.Overwrite;
             RawConvert = preset.Settings.RawConvert;
 
@@ -237,6 +238,25 @@
         /// Gets or sets base Folder to use when building the Cloudinary public_id.
         /// </summary>
         public string Folder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the folder where the asset is stored in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to automatically assign the filename of the uploaded asset as the asset’s display name in the Media Library.
+        /// Relevant only if DisplayName is not passed.
+        /// </summary>
+        public bool? UseFilenameAsDisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets whether to automatically apply the path specified
+        /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
+        /// to a folder in the Media Library) as a prefix to the public_id value.
+        /// </summary>
+        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
 
         /// <summary>
         /// Gets or sets whether to overwrite existing resources with the same public ID.
@@ -431,6 +451,9 @@
             AddParam(dict, "notification_url", NotificationUrl);
             AddParam(dict, "proxy", Proxy);
             AddParam(dict, "folder", Folder);
+            AddParam(dict, "use_filename_as_display_name", UseFilenameAsDisplayName);
+            AddParam(dict, "asset_folder", AssetFolder);
+            AddParam(dict, "use_asset_folder_as_public_id_prefix", UseAssetFolderAsPublicIdPrefix);
             AddParam(dict, "raw_convert", RawConvert);
             AddParam(dict, "backup", Backup);
             AddParam(dict, "overwrite", Overwrite);

--- a/CloudinaryDotNet/Actions/PresetsUpload/UploadPresetParams.cs
+++ b/CloudinaryDotNet/Actions/PresetsUpload/UploadPresetParams.cs
@@ -256,7 +256,7 @@
         /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
         /// to a folder in the Media Library) as a prefix to the public_id value.
         /// </summary>
-        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+        public bool? UseAssetFolderAsPublicIdPrefix { get; set; }
 
         /// <summary>
         /// Gets or sets whether to overwrite existing resources with the same public ID.

--- a/CloudinaryDotNet/Actions/PresetsUpload/UploadSettings.cs
+++ b/CloudinaryDotNet/Actions/PresetsUpload/UploadSettings.cs
@@ -67,6 +67,21 @@
         public bool DiscardOriginalFilename { get; set; }
 
         /// <summary>
+        /// Gets or sets the folder where the asset is stored in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        [DataMember(Name = "asset_folder")]
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets whether to automatically apply the path specified
+        /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
+        /// to a folder in the Media Library) as a prefix to the public_id value.
+        /// </summary>
+        [DataMember(Name = "use_asset_folder_as_public_id_prefix")]
+        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+
+        /// <summary>
         /// Gets or sets an HTTP URL to send notification to (a webhook) when the upload is completed.
         /// </summary>
         [DataMember(Name = "notification_url")]

--- a/CloudinaryDotNet/Actions/PresetsUpload/UploadSettings.cs
+++ b/CloudinaryDotNet/Actions/PresetsUpload/UploadSettings.cs
@@ -78,8 +78,8 @@
         /// in the asset_folder parameter (or the folder that's in focus when an asset is uploaded directly
         /// to a folder in the Media Library) as a prefix to the public_id value.
         /// </summary>
-        [DataMember(Name = "use_asset_folder_as_public_id_prefix")]
-        public bool UseAssetFolderAsPublicIdPrefix { get; set; }
+        [DataMember(Name = "use_asset_folder_as_public_id_prefix", EmitDefaultValue = false)]
+        public bool? UseAssetFolderAsPublicIdPrefix { get; set; }
 
         /// <summary>
         /// Gets or sets an HTTP URL to send notification to (a webhook) when the upload is completed.

--- a/CloudinaryDotNet/Actions/Search/SearchResource.cs
+++ b/CloudinaryDotNet/Actions/Search/SearchResource.cs
@@ -18,6 +18,12 @@
         protected string m_resourceType;
 
         /// <summary>
+        /// Gets or sets the ID of uploaded asset.
+        /// </summary>
+        [DataMember(Name = "asset_id")]
+        public string AssetId { get; set; }
+
+        /// <summary>
         /// Gets or sets the public id of the asset.
         /// </summary>
         [DataMember(Name = "public_id")]
@@ -28,6 +34,20 @@
         /// </summary>
         [DataMember(Name = "folder")]
         public string Folder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the folder where the asset is stored in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        [DataMember(Name = "asset_folder")]
+        public string AssetFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name that is displayed for the asset in the Media Library.
+        /// This value does not impact the asset’s Public ID.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the resource file.

--- a/CloudinaryDotNet/Cloudinary.AdminApi.cs
+++ b/CloudinaryDotNet/Cloudinary.AdminApi.cs
@@ -345,6 +345,46 @@ namespace CloudinaryDotNet
         }
 
         /// <summary>
+        /// Returns resources in the specified asset folder asynchronously.
+        /// </summary>
+        /// <param name="assetFolder">Asset Folder.</param>
+        /// <param name="tags">Whether to include tags in result.</param>
+        /// <param name="context">Whether to include context in result.</param>
+        /// <param name="moderations">Whether to include moderation status in result.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of the resources listing.</returns>
+        public Task<ListResourcesResult> ListResourceByAssetFolderAsync(
+            string assetFolder,
+            bool tags,
+            bool context,
+            bool moderations,
+            CancellationToken? cancellationToken = null)
+        {
+            var listResourcesByAssetFolderParamsParams = new ListResourcesByAssetFolderParams()
+            {
+                AssetFolder = assetFolder,
+                Tags = tags,
+                Context = context,
+                Moderations = moderations,
+            };
+            return ListResourcesAsync(listResourcesByAssetFolderParamsParams, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a list of resources in the specified asset folder.
+        /// </summary>
+        /// <param name="assetFolder">Asset folder.</param>
+        /// <param name="tags">Whether to include tags in result.</param>
+        /// <param name="context">Whether to include context in result.</param>
+        /// <param name="moderations">Whether to include moderation status in result.</param>
+        /// <returns>Parsed result of the resources listing.</returns>
+        public ListResourcesResult ListResourcesByAssetFolder(string assetFolder, bool tags = false, bool context = false, bool moderations = false)
+        {
+            return ListResourceByAssetFolderAsync(assetFolder, tags, context, moderations, null)
+                .GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Lists resources by moderation status asynchronously.
         /// </summary>
         /// <param name="kind">The moderation kind.</param>
@@ -1976,9 +2016,18 @@ namespace CloudinaryDotNet
         {
             var url = GetResourcesUrl();
 
-            var prefix = ((parameters as ListSpecificResourcesParams)?.AssetIds.Count > 0) ?
-                "by_asset_ids"
-                : ApiShared.GetCloudinaryParam(parameters.ResourceType);
+            // FIXME: refactor this
+            var prefix = ApiShared.GetCloudinaryParam(parameters.ResourceType);
+
+            if ((parameters as ListSpecificResourcesParams)?.AssetIds.Count > 0)
+            {
+                prefix = "by_asset_ids";
+            }
+            else if (!string.IsNullOrEmpty((parameters as ListResourcesByAssetFolderParams)?.AssetFolder))
+            {
+                prefix = "by_asset_folder";
+            }
+
             url.Add(prefix);
 
             switch (parameters)


### PR DESCRIPTION
### Brief Summary of Changes
This PR adds support for `ListResourcesByAssetFolder` Admin API

In addition it adds support for `AssetFolder`, `DisplayName`,  `UniqueDisplayName` and `UseAssetFolderAsPublicIdPrefix` parameters

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
