### PR TITLE
Add support for delivery `Type` setter in URL

### DIFF
--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -518,7 +518,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
 
             var expectedUrl = uploadresponse.SecureUrl.OriginalString;
 
-            var computedUrl = m_cloudinary.Api.UrlImgUp.Action("authenticated").Version(uploadresponse.Version).Secure(true).Signed(true).BuildUrl(publicId + ".jpg");
+            var computedUrl = m_cloudinary.Api.UrlImgUp.Type("authenticated").Version(uploadresponse.Version).Secure(true).Signed(true).BuildUrl(publicId + ".jpg");
 
             Assert.AreEqual(expectedUrl, computedUrl);
 

--- a/CloudinaryDotNet.Tests/Transformations/Image/SpriteTest.cs
+++ b/CloudinaryDotNet.Tests/Transformations/Image/SpriteTest.cs
@@ -29,10 +29,10 @@ namespace CloudinaryDotNet.Tests.Transformations.Image
         {
             // should build urls to get sprite css and picture by tag (with transformations and prefix)
 
-            var uri = m_api.UrlImgUp.Action("sprite").BuildUrl("teslistresourcesbytag1.png");
+            var uri = m_api.UrlImgUp.Type("sprite").BuildUrl("teslistresourcesbytag1.png");
             Assert.AreEqual(TestConstants.DefaultRootPath + "image/sprite/teslistresourcesbytag1.png", uri);
 
-            uri = m_api.UrlImgUp.Action("sprite").BuildUrl("teslistresourcesbytag1.css");
+            uri = m_api.UrlImgUp.Type("sprite").BuildUrl("teslistresourcesbytag1.css");
             Assert.AreEqual(TestConstants.DefaultRootPath + "image/sprite/teslistresourcesbytag1.css", uri);
 
             uri = m_api.ApiUrlImgUpV.CloudinaryAddr("http://api.cloudinary.com").Action("sprite").BuildUrl();
@@ -44,7 +44,7 @@ namespace CloudinaryDotNet.Tests.Transformations.Image
         {
             // should build urls to get sprite css and picture by tag with prefix
 
-            string uri = m_api.UrlImgUp.Action("sprite").Add("p_home_thing_").BuildUrl("logo.css");
+            string uri = m_api.UrlImgUp.Type("sprite").Add("p_home_thing_").BuildUrl("logo.css");
             Assert.AreEqual(TestConstants.DefaultRootPath + "image/sprite/p_home_thing_/logo.css", uri);
         }
 

--- a/CloudinaryDotNet/Url.cs
+++ b/CloudinaryDotNet/Url.cs
@@ -314,14 +314,24 @@
         }
 
         /// <summary>
-        /// Add action to the URL.
+        /// Set action of the URL.
         /// </summary>
         /// <param name="action">The action.</param>
-        /// <returns>The delivery URL with action applied.</returns>
+        /// <returns>The delivery/API URL with action applied.</returns>
         public Url Action(string action)
         {
             m_action = action;
             return this;
+        }
+
+        /// <summary>
+        /// Set delivery type of the asset URL.
+        /// </summary>
+        /// <param name="deliveryType">The delivery type of the asset.</param>
+        /// <returns>The delivery URL with delivery type applied.</returns>
+        public Url Type(string deliveryType)
+        {
+            return Action(deliveryType);
         }
 
         /// <summary>


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
