### PR TITLE
Add support for `UploadChunk` in Upload Api

### DIFF
--- a/CloudinaryDotNet.IntegrationTests/IntegrationTestBase.cs
+++ b/CloudinaryDotNet.IntegrationTests/IntegrationTestBase.cs
@@ -180,7 +180,7 @@ namespace CloudinaryDotNet.IntegrationTests
             SaveEmbeddedToDisk(assembly, TEST_PDF, m_testPdfPath);
         }
 
-        private void SaveEmbeddedToDisk(Assembly assembly, string sourcePath, string destPath)
+        private static void SaveEmbeddedToDisk(Assembly assembly, string sourcePath, string destPath)
         {
             try
             {
@@ -204,6 +204,34 @@ namespace CloudinaryDotNet.IntegrationTests
             {
 
             }
+        }
+
+
+        protected List<string> SplitFile(string sourceFile, int chunkSize)
+        {
+            var chunks = new List<string>();
+
+            var baseName = Path.GetFileNameWithoutExtension(sourceFile);
+            var extension = Path.GetExtension(sourceFile);
+            var buffer = new byte[chunkSize];
+            using (var fs = new FileStream(sourceFile, FileMode.Open, FileAccess.Read))
+            {
+                int read;
+                var currChunkNum = 0;
+                while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    var path = $"{Path.GetDirectoryName(sourceFile)}/{baseName}.{currChunkNum}{extension}.tmp";
+                    using (var outputFile = new FileStream(path, FileMode.Create, FileAccess.Write))
+                    {
+                        outputFile.Write(buffer, 0, read);
+                    }
+
+                    chunks.Add(path);
+                    currChunkNum++;
+                }
+            }
+
+            return chunks;
         }
 
         /// <summary>

--- a/CloudinaryDotNet.IntegrationTests/IntegrationTestBase.cs
+++ b/CloudinaryDotNet.IntegrationTests/IntegrationTestBase.cs
@@ -207,7 +207,7 @@ namespace CloudinaryDotNet.IntegrationTests
         }
 
 
-        protected List<string> SplitFile(string sourceFile, int chunkSize)
+        protected List<string> SplitFile(string sourceFile, int chunkSize, string suffix = "")
         {
             var chunks = new List<string>();
 
@@ -220,7 +220,7 @@ namespace CloudinaryDotNet.IntegrationTests
                 var currChunkNum = 0;
                 while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
                 {
-                    var path = $"{Path.GetDirectoryName(sourceFile)}/{baseName}.{currChunkNum}{extension}.tmp";
+                    var path = $"{Path.GetDirectoryName(sourceFile)}/{baseName}.{currChunkNum}{suffix}{extension}.tmp";
                     using (var outputFile = new FileStream(path, FileMode.Create, FileAccess.Write))
                     {
                         outputFile.Write(buffer, 0, read);

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -762,7 +762,14 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
                 uploadParams.File.Dispose();
                 foreach (var chunk in fileChunks)
                 {
-                    File.Delete(chunk);
+                    try
+                    {
+                        File.Delete(chunk);
+                    }
+                    catch (IOException)
+                    {
+                        // nothing to do
+                    }
                 }
             }
 
@@ -800,7 +807,14 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
                 uploadParams.File.Dispose();
                 foreach (var chunk in fileChunks)
                 {
-                    File.Delete(chunk);
+                    try
+                    {
+                        File.Delete(chunk);
+                    }
+                    catch (IOException)
+                    {
+                        // nothing to do
+                    }
                 }
             }
 

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -161,7 +161,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             Assert.AreEqual(TEST_PDF_PAGES_COUNT, uploadResult.Pages);
         }
 
-        [Test]
+        [Test, RetryWithDelay]
         public void TestUploadLocalImageTimeout()
         {
             const int TIMEOUT = 1000;
@@ -739,7 +739,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
 
             ImageUploadResult result = null;
 
-            var fileChunks = SplitFile(largeFilePath, TEST_CHUNK_SIZE);
+            var fileChunks = SplitFile(largeFilePath, TEST_CHUNK_SIZE, "multiple");
 
             var uploadParams =  new ImageUploadParams()
             {
@@ -783,7 +783,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             var largeFilePath = m_testLargeImagePath;
             var largeFileLength = (int)new FileInfo(largeFilePath).Length;
 
-            var fileChunks = SplitFile(largeFilePath, TEST_CHUNK_SIZE);
+            var fileChunks = SplitFile(largeFilePath, TEST_CHUNK_SIZE, "multiple_parallel");
 
             var uploadParams =  new RawUploadParams()
             {

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -260,7 +260,7 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             Assert.AreEqual(MODERATION_MANUAL, uploadResult.Moderation[0].Kind);
             Assert.AreEqual(ModerationStatus.Pending, uploadResult.Moderation[0].Status);
 
-            var getResult = m_cloudinary.GetResource(uploadResult.PublicId);
+            var getResult = m_cloudinary.GetResourceByAssetId(uploadResult.AssetId);
 
             Assert.NotNull(getResult);
             Assert.NotNull(getResult.Moderation, getResult.Error?.Message);

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -677,7 +677,6 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
 
                 using (var source = File.Open(largeFilePath, FileMode.Open))
                 {
-
                     int read;
                     while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
                     {
@@ -765,7 +764,14 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             {
                 foreach (var chunk in fileChunks)
                 {
-                    File.Delete(chunk);
+                    try
+                    {
+                        File.Delete(chunk);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
             }
 

--- a/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/UploadApi/UploadMethodsTest.cs
@@ -759,16 +759,10 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             }
             finally
             {
+                uploadParams.File.Dispose();
                 foreach (var chunk in fileChunks)
                 {
-                    try
-                    {
-                        File.Delete(chunk);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
+                    File.Delete(chunk);
                 }
             }
 
@@ -803,16 +797,10 @@ namespace CloudinaryDotNet.IntegrationTests.UploadApi
             }
             finally
             {
+                uploadParams.File.Dispose();
                 foreach (var chunk in fileChunks)
                 {
-                    try
-                    {
-                        File.Delete(chunk);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
+                    File.Delete(chunk);
                 }
             }
 

--- a/CloudinaryDotNet.Tests/Asset/UrlBuilderTest.cs
+++ b/CloudinaryDotNet.Tests/Asset/UrlBuilderTest.cs
@@ -485,13 +485,13 @@ namespace CloudinaryDotNet.Tests.Asset
         [Test]
         public void TestAgentPlatformHeaders()
         {
-            var request = new HttpRequestMessage { RequestUri = new Uri("http://dummy.com") };
+            var request = new HttpRequestMessage { RequestUri = new Uri("https://dummy.com") };
             m_api.UserPlatform = "Test/1.0";
 
-            m_api.PrepareRequestBody(
+            m_api.PrepareRequestBodyAsync(
                 request,
                 HttpMethod.GET,
-                new SortedDictionary<string, object>());
+                new SortedDictionary<string, object>()).GetAwaiter().GetResult();
 
             //Can't test the result, so we just verify the UserAgent parameter is sent to the server
             StringAssert.AreEqualIgnoringCase($"{m_api.UserPlatform} {ApiShared.USER_AGENT}",

--- a/CloudinaryDotNet/Actions/AssetsUpload/BasicRawUploadParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/BasicRawUploadParams.cs
@@ -59,6 +59,11 @@
         public string Signature { get; set; }
 
         /// <summary>
+        /// Gets or sets unique upload ID.
+        /// </summary>
+        public string UniqueUploadId { get; set; }
+
+        /// <summary>
         /// Validate object model.
         /// </summary>
         public override void Check()

--- a/CloudinaryDotNet/Actions/AssetsUpload/BasicRawUploadParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/BasicRawUploadParams.cs
@@ -73,7 +73,7 @@
                 throw new ArgumentException("File must be specified in UploadParams!");
             }
 
-            if (!File.IsRemote && File.Stream == null && string.IsNullOrEmpty(File.FilePath))
+            if (!File.Chunked && !File.IsRemote && File.Stream == null && string.IsNullOrEmpty(File.FilePath))
             {
                 throw new ArgumentException("File is not ready!");
             }

--- a/CloudinaryDotNet/Actions/AssetsUpload/ExplicitResult.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/ExplicitResult.cs
@@ -26,12 +26,6 @@
         public List<ResponsiveBreakpointList> ResponsiveBreakpoints { get; set; }
 
         /// <summary>
-        /// Gets or sets a status that is returned when passing 'Async' argument set to 'true' to the server.
-        /// </summary>
-        [DataMember(Name = "status")]
-        public string Status { get; set; }
-
-        /// <summary>
         /// Gets or sets any requested information from executing one of the Cloudinary Add-ons on the media asset.
         /// </summary>
         [DataMember(Name = "info")]

--- a/CloudinaryDotNet/Actions/AssetsUpload/UploadResult.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/UploadResult.cs
@@ -103,6 +103,12 @@
         public JToken MetadataFields { get; set; }
 
         /// <summary>
+        /// Gets or sets a status that is returned when passing 'Async' argument set to 'true' to the server.
+        /// </summary>
+        [DataMember(Name = "status")]
+        public string Status { get; set; }
+
+        /// <summary>
         /// Gets or sets upload hook execution status.
         /// </summary>
         [DataMember(Name = "hook_execution")]

--- a/CloudinaryDotNet/Actions/AssetsUpload/VideoUploadParams.cs
+++ b/CloudinaryDotNet/Actions/AssetsUpload/VideoUploadParams.cs
@@ -8,9 +8,6 @@
         /// <summary>
         /// Gets get the type of video asset for upload.
         /// </summary>
-        public override ResourceType ResourceType
-        {
-            get { return Actions.ResourceType.Video; }
-        }
+        public override ResourceType ResourceType => ResourceType.Video;
     }
 }

--- a/CloudinaryDotNet/ApiShared.Internal.cs
+++ b/CloudinaryDotNet/ApiShared.Internal.cs
@@ -213,10 +213,7 @@
         /// <returns>Unsigned cloudinary parameters with upload preset included.</returns>
         protected static SortedDictionary<string, object> BuildUnsignedUploadParams(string preset, SortedDictionary<string, object> parameters = null)
         {
-            if (parameters == null)
-            {
-                parameters = new SortedDictionary<string, object>();
-            }
+            parameters ??= new SortedDictionary<string, object>();
 
             parameters.Add("upload_preset", preset);
             parameters.Add("unsigned", true);
@@ -284,17 +281,13 @@
         {
             try
             {
-                using (var streamReader = new StreamReader(s))
-                {
-                    using (var jsonReader = new JsonTextReader(streamReader))
-                    {
-                        var jsonObj = JToken.Load(jsonReader);
-                        var result = jsonObj.ToObject<T>();
-                        result.JsonObj = jsonObj;
+                using var streamReader = new StreamReader(s);
+                using var jsonReader = new JsonTextReader(streamReader);
+                var jsonObj = JToken.Load(jsonReader);
+                var result = jsonObj.ToObject<T>();
+                result.JsonObj = jsonObj;
 
-                        return result;
-                    }
-                }
+                return result;
             }
             catch (JsonException jex)
             {
@@ -342,24 +335,6 @@
         private static bool IsContentRange(Dictionary<string, string> extraHeaders) =>
             extraHeaders != null && extraHeaders.ContainsKey("X-Unique-Upload-Id");
 
-        private static void SetContentRange(IDictionary<string, string> extraHeaders, FileDescription file)
-        {
-            var startOffset = file.CurrPos - file.CurrChunkSize;
-            long endOffset = -1;
-            if (file.GetFileLength() > 0)
-            {
-                endOffset = file.GetFileLength();
-            }
-            else if (file.Eof)
-            {
-                endOffset = file.CurrPos;
-            }
-
-            extraHeaders["Content-Range"] = $"bytes {startOffset}-{file.CurrPos - 1}/{endOffset}";
-        }
-
-        private static Stream GetFileStream(FileDescription file) => file.Stream ?? File.OpenRead(file.FilePath);
-
         private static void SetStreamContent(string fieldName, FileDescription file, Stream stream, MultipartFormDataContent content)
         {
             var streamContent = new StreamContent(stream);
@@ -387,26 +362,6 @@
             extraHeaders != null &&
             extraHeaders.TryGetValue(Constants.HEADER_CONTENT_TYPE, out var value) &&
             value == Constants.CONTENT_TYPE_APPLICATION_JSON;
-
-        private static Stream WriterStreamFromBegin(StreamWriter writer)
-        {
-            var stream = writer.BaseStream;
-            stream.Seek(0, SeekOrigin.Begin);
-            return stream;
-        }
-
-        private static StreamWriter SetStreamToStartAndCreateWriter(FileDescription file, Stream stream)
-        {
-            var memStream = new MemoryStream();
-            var writer = new StreamWriter(memStream) { AutoFlush = true };
-
-            if (stream.CanSeek)
-            {
-                stream.Seek(file.CurrChunkPos, SeekOrigin.Begin);
-            }
-
-            return writer;
-        }
 
         private static void SetHeadersAndContent(HttpRequestMessage request, Dictionary<string, string> extraHeaders, HttpContent content)
         {
@@ -443,7 +398,7 @@
             }
         }
 
-        private async Task<HttpContent> CreateMultipartContentAsync(
+        private static async Task<HttpContent> CreateMultipartContentAsync(
             SortedDictionary<string, object> parameters,
             Dictionary<string, string> extraHeaders = null,
             CancellationToken? cancellationToken = null)
@@ -458,15 +413,18 @@
                         break;
                     case FileDescription file:
                     {
-                        var stream = GetFileStream(file);
-
+                        Stream stream;
                         if (IsContentRange(extraHeaders))
                         {
-                            // Unfortunately we don't have ByteRangeStreamContent here,
-                            // let's create another stream from the original one
-                            stream = await GetRangeFromFileAsync(file, stream, cancellationToken).ConfigureAwait(false);
+                            var chunk = await file.GetNextChunkAsync(cancellationToken).ConfigureAwait(false);
 
-                            SetContentRange(extraHeaders, file);
+                            stream = chunk.Chunk;
+
+                            extraHeaders!["Content-Range"] = $"bytes {chunk.StartByte}-{chunk.EndByte}/{chunk.TotalBytes}";
+                        }
+                        else
+                        {
+                            stream = file.GetFileStream();
                         }
 
                         SetStreamContent(param.Key, file, stream, content);
@@ -492,7 +450,7 @@
             return content;
         }
 
-        private HttpContent CreateMultipartContent(
+        private static HttpContent CreateMultipartContent(
             SortedDictionary<string, object> parameters,
             Dictionary<string, string> extraHeaders = null)
         {
@@ -501,19 +459,20 @@
             {
                 switch (param.Value)
                 {
-                    case FileDescription file when file.IsRemote:
+                    case FileDescription { IsRemote: true } file:
                         SetContentForRemoteFile(param.Key, file, content);
                         break;
                     case FileDescription file:
                     {
-                        var stream = GetFileStream(file);
+                        var stream = file.GetFileStream();
 
                         if (IsContentRange(extraHeaders))
                         {
-                            // Unfortunately we don't have ByteRangeStreamContent here,
-                            // let's create another stream from the original one
-                            stream = GetRangeFromFile(file, stream);
-                            SetContentRange(extraHeaders, file);
+                            var chunk = file.GetNextChunkAsync().GetAwaiter().GetResult();
+
+                            stream = chunk.Chunk;
+
+                            extraHeaders!["Content-Range"] = $"bytes {chunk.StartByte}-{chunk.EndByte}/{chunk.TotalBytes}";
                         }
 
                         SetStreamContent(param.Key, file, stream, content);
@@ -617,65 +576,6 @@
                 : CreateMultipartContent(parameters, extraHeaders);
 
             SetHeadersAndContent(request, extraHeaders, content);
-        }
-
-        private async Task<Stream> GetRangeFromFileAsync(FileDescription file, Stream stream, CancellationToken? cancellationToken = null)
-        {
-            var writer = SetStreamToStartAndCreateWriter(file, stream);
-            file.CurrChunkSize = await ReadBytesAsync(writer, stream, file.BufferSize, cancellationToken).ConfigureAwait(false);
-            file.ShiftCurrPos(file.CurrChunkSize);
-            if ((file.BufferSize != int.MaxValue && file.CurrChunkSize < file.BufferSize) || file.LastChunk)
-            {
-                file.Eof = true; // last chunk
-            }
-
-            return WriterStreamFromBegin(writer);
-        }
-
-        private Stream GetRangeFromFile(FileDescription file, Stream stream)
-        {
-            var writer = SetStreamToStartAndCreateWriter(file, stream);
-            file.CurrChunkSize = ReadBytes(writer, stream, file.BufferSize);
-            file.ShiftCurrPos(file.CurrChunkSize);
-            if ((file.BufferSize != int.MaxValue && file.CurrChunkSize < file.BufferSize) || file.LastChunk)
-            {
-                file.Eof = true; // last chunk
-            }
-
-            return WriterStreamFromBegin(writer);
-        }
-
-        private async Task<int> ReadBytesAsync(StreamWriter writer, Stream stream, int length, CancellationToken? cancellationToken = null)
-        {
-            int bytesSent = 0;
-            byte[] buf = new byte[ChunkSize];
-            int toSend;
-            int cnt;
-            var token = cancellationToken ?? CancellationToken.None;
-            while ((toSend = length - bytesSent) > 0
-                && (cnt = await stream.ReadAsync(buf, 0, toSend > buf.Length ? buf.Length : toSend, token).ConfigureAwait(false)) > 0)
-            {
-                await writer.BaseStream.WriteAsync(buf, 0, cnt, token).ConfigureAwait(false);
-                bytesSent += cnt;
-            }
-
-            return bytesSent;
-        }
-
-        private int ReadBytes(StreamWriter writer, Stream stream, int length)
-        {
-            int bytesSent = 0;
-            byte[] buf = new byte[ChunkSize];
-            int toSend;
-            int cnt;
-            while ((toSend = length - bytesSent) > 0
-                && (cnt = stream.Read(buf, 0, toSend > buf.Length ? buf.Length : toSend)) > 0)
-            {
-                writer.BaseStream.Write(buf, 0, cnt);
-                bytesSent += cnt;
-            }
-
-            return bytesSent;
         }
     }
 }

--- a/CloudinaryDotNet/ApiShared.cs
+++ b/CloudinaryDotNet/ApiShared.cs
@@ -440,6 +440,7 @@
         /// <param name="extraHeaders">Headers to add to the request.</param>
         /// <param name="cancellationToken">(Optional) Cancellation token.</param>
         /// <returns>Instance of the parsed response from the cloudinary API.</returns>
+        [Obsolete("Passing FileDescription to CallAndParseAsync is deprecated.")]
         public async Task<T> CallAndParseAsync<T>(
             HttpMethod method,
             string url,
@@ -449,16 +450,14 @@
             CancellationToken? cancellationToken = null)
             where T : BaseResult, new()
         {
-            using (var response = await CallAsync(
+            using var response = await CallAsync(
                 method,
                 url,
                 parameters,
                 file,
                 extraHeaders,
-                cancellationToken).ConfigureAwait(false))
-            {
-                return await ParseAsync<T>(response).ConfigureAwait(false);
-            }
+                cancellationToken).ConfigureAwait(false);
+            return await ParseAsync<T>(response).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -479,15 +478,13 @@
             CancellationToken? cancellationToken = null)
             where T : BaseResult, new()
         {
-            using (var response = await CallAsync(
-                       method,
-                       url,
-                       parameters,
-                       extraHeaders,
-                       cancellationToken).ConfigureAwait(false))
-            {
-                return await ParseAsync<T>(response).ConfigureAwait(false);
-            }
+            using var response = await CallAsync(
+                method,
+                url,
+                parameters,
+                extraHeaders,
+                cancellationToken).ConfigureAwait(false);
+            return await ParseAsync<T>(response).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -578,17 +575,15 @@
             Dictionary<string, string> extraHeaders = null,
             CancellationToken? cancellationToken = null)
         {
-            using (var request =
-                   await PrepareRequestBodyAsync(
-                       requestBuilder(PrepareRequestUrl(method, url, parameters)),
-                       method,
-                       parameters,
-                       extraHeaders,
-                       cancellationToken).ConfigureAwait(false))
-            {
-                var httpCancellationToken = cancellationToken ?? GetDefaultCancellationToken();
-                return await Client.SendAsync(request, httpCancellationToken).ConfigureAwait(false);
-            }
+            using var request =
+                await PrepareRequestBodyAsync(
+                    requestBuilder(PrepareRequestUrl(method, url, parameters)),
+                    method,
+                    parameters,
+                    extraHeaders,
+                    cancellationToken).ConfigureAwait(false);
+            var httpCancellationToken = cancellationToken ?? GetDefaultCancellationToken();
+            return await Client.SendAsync(request, httpCancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -626,17 +621,7 @@
             SortedDictionary<string, object> parameters,
             Dictionary<string, string> extraHeaders = null)
         {
-            using (var request = requestBuilder(PrepareRequestUrl(method, url, parameters)))
-            {
-                PrepareRequestBody(request, method, parameters, extraHeaders);
-
-                var cancellationToken = GetDefaultCancellationToken();
-
-                return Client
-                    .SendAsync(request, cancellationToken)
-                    .GetAwaiter()
-                    .GetResult();
-            }
+            return CallAsync(method, url, parameters, extraHeaders).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -658,12 +643,9 @@
         /// <returns>JSON representation of upload parameters.</returns>
         public string PrepareUploadParams(IDictionary<string, object> parameters)
         {
-            if (parameters == null)
-            {
-                parameters = new SortedDictionary<string, object>();
-            }
+            parameters ??= new SortedDictionary<string, object>();
 
-            if (!(parameters is SortedDictionary<string, object>))
+            if (parameters is not SortedDictionary<string, object>)
             {
                 parameters = new SortedDictionary<string, object>(parameters);
             }

--- a/CloudinaryDotNet/ApiShared.cs
+++ b/CloudinaryDotNet/ApiShared.cs
@@ -390,10 +390,8 @@
         /// <returns>Cloudinary-compatible parameter.</returns>
         public static string GetCloudinaryParam<T>(T e)
         {
-            Type eType = typeof(T);
-            FieldInfo fi = eType.GetRuntimeField(e.ToString());
-            EnumMemberAttribute[] attrs = (EnumMemberAttribute[])fi.GetCustomAttributes(
-                typeof(EnumMemberAttribute), false);
+            var fi = typeof(T).GetRuntimeField(e.ToString());
+            var attrs = (EnumMemberAttribute[])fi.GetCustomAttributes(typeof(EnumMemberAttribute), false);
 
             if (attrs.Length == 0)
             {

--- a/CloudinaryDotNet/Cloudinary.UploadApi.cs
+++ b/CloudinaryDotNet/Cloudinary.UploadApi.cs
@@ -87,7 +87,7 @@ namespace CloudinaryDotNet
             FileDescription fileDescription,
             CancellationToken? cancellationToken = null)
         {
-            var uri = GetUploadUrl(resourceType);
+            var uri = m_api.GetUploadUrl(resourceType);
 
             fileDescription.Reset();
 
@@ -119,13 +119,12 @@ namespace CloudinaryDotNet
         /// <returns>Parsed result of the raw file uploading.</returns>
         public Task<RawUploadResult> UploadAsync(RawUploadParams parameters, string type = "auto", CancellationToken? cancellationToken = null)
         {
-            string uri = m_api.ApiUrlImgUpV.ResourceType(type).BuildUrl();
-
+            CheckUploadParameters(parameters);
             parameters.File.Reset();
 
             return CallUploadApiAsync<RawUploadResult>(
                 HttpMethod.POST,
-                uri,
+                GetUploadUrl(parameters),
                 parameters,
                 cancellationToken);
         }
@@ -138,7 +137,7 @@ namespace CloudinaryDotNet
         /// <returns>Parsed result of the raw file uploading.</returns>
         public RawUploadResult Upload(RawUploadParams parameters, string type = "auto")
         {
-            return UploadAsync(parameters, type, null).GetAwaiter().GetResult();
+            return UploadAsync(parameters, type).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -292,14 +291,7 @@ namespace CloudinaryDotNet
         [Obsolete("Use UploadLarge(parameters, bufferSize) instead.")]
         public UploadResult UploadLarge(BasicRawUploadParams parameters, int bufferSize = DEFAULT_CHUNK_SIZE, bool isRaw = false)
         {
-            if (isRaw)
-            {
-                return UploadLarge<RawUploadResult>(parameters, bufferSize);
-            }
-            else
-            {
-                return UploadLarge<ImageUploadResult>(parameters, bufferSize);
-            }
+            return isRaw ? UploadLarge<RawUploadResult>(parameters, bufferSize) : UploadLarge<ImageUploadResult>(parameters, bufferSize);
         }
 
         /// <summary>
@@ -323,19 +315,13 @@ namespace CloudinaryDotNet
                 return await UploadAsync<T>(parameters).ConfigureAwait(false);
             }
 
-            var internalParams = new UploadLargeParams(parameters, bufferSize, m_api);
+            parameters.File.Reset(bufferSize != 0 ? bufferSize : DEFAULT_CHUNK_SIZE);
+
             T result = null;
 
             while (!parameters.File.Eof)
             {
-                UpdateContentRange(internalParams);
-                result = await CallUploadApiAsync<T>(
-                    HttpMethod.POST,
-                    internalParams.Url,
-                    parameters,
-                    cancellationToken,
-                    internalParams.Headers).ConfigureAwait(false);
-                CheckUploadResult(result);
+                result = await UploadChunkAsync<T>(parameters, cancellationToken).ConfigureAwait(false);
             }
 
             return result;
@@ -352,6 +338,127 @@ namespace CloudinaryDotNet
             where T : UploadResult, new()
         {
             return UploadLargeAsync<T>(parameters, bufferSize).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a file to Cloudinary asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type of result of upload.</typeparam>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public async Task<T> UploadChunkAsync<T>(
+            BasicRawUploadParams parameters,
+            CancellationToken? cancellationToken = null)
+            where T : UploadResult, new()
+        {
+            CheckUploadParameters(parameters);
+
+            if (string.IsNullOrEmpty(parameters.UniqueUploadId))
+            {
+                // The first chunk
+                parameters.UniqueUploadId = Utils.RandomPublicId();
+            }
+
+            // Mark upload as chunked in order to set appropriate content range header.
+            parameters.File.Chunked = true;
+
+            var headers = new Dictionary<string, string>
+            {
+                ["X-Unique-Upload-Id"] = parameters.UniqueUploadId,
+            };
+
+            var result = await CallUploadApiAsync<T>(
+                HttpMethod.POST,
+                GetUploadUrl(parameters),
+                parameters,
+                cancellationToken,
+                headers).ConfigureAwait(false);
+
+            CheckUploadResult(result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a file to Cloudinary.
+        /// </summary>
+        /// <typeparam name="T">The type of result of upload.</typeparam>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public T UploadChunk<T>(BasicRawUploadParams parameters)
+            where T : UploadResult, new()
+        {
+            return UploadChunkAsync<T>(parameters).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a raw file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public Task<RawUploadResult> UploadChunkAsync(
+            RawUploadParams parameters,
+            CancellationToken? cancellationToken = null)
+        {
+            return UploadChunkAsync<RawUploadResult>(parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of an image file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public Task<ImageUploadResult> UploadChunkAsync(
+            ImageUploadParams parameters,
+            CancellationToken? cancellationToken = null)
+        {
+            return UploadChunkAsync<ImageUploadResult>(parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a video file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public Task<VideoUploadResult> UploadChunkAsync(
+            VideoUploadParams parameters,
+            CancellationToken? cancellationToken = null)
+        {
+            return UploadChunkAsync<VideoUploadResult>(parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a raw file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public RawUploadResult UploadChunk(RawUploadParams parameters)
+        {
+            return UploadChunk<RawUploadResult>(parameters);
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of an image file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public ImageUploadResult UploadChunk(ImageUploadParams parameters)
+        {
+            return UploadChunk<ImageUploadResult>(parameters);
+        }
+
+        /// <summary>
+        /// Uploads a single chunk of a video file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        public VideoUploadResult UploadChunk(VideoUploadParams parameters)
+        {
+            return UploadChunk<VideoUploadResult>(parameters);
         }
 
         /// <summary>
@@ -943,12 +1050,14 @@ namespace CloudinaryDotNet
         private static void CheckUploadResult<T>(T result)
             where T : UploadResult, new()
         {
-            if (result.StatusCode != HttpStatusCode.OK)
+            if (result.StatusCode == HttpStatusCode.OK)
             {
-                var error = result.Error != null ? result.Error.Message : "Unknown error";
-                throw new Exception(
-                    $"An error has occured while uploading file (status code: {result.StatusCode}). {error}");
+                return;
             }
+
+            var error = result.Error != null ? result.Error.Message : "Unknown error";
+            throw new Exception(
+                $"An error has occurred while uploading file (status code: {result.StatusCode}). {error}");
         }
 
         private static void CheckUploadParameters(BasicRawUploadParams parameters)
@@ -962,19 +1071,6 @@ namespace CloudinaryDotNet
             {
                 throw new ArgumentException("Parameters.File parameter should be defined");
             }
-        }
-
-        private static void UpdateContentRange(UploadLargeParams internalParams)
-        {
-            var fileDescription = internalParams.Parameters.File;
-            var fileLength = fileDescription.GetFileLength();
-            var startOffset = fileDescription.BytesSent;
-            var buffSize = fileLength > 0
-                ? Math.Min(internalParams.BufferSize, fileLength - startOffset)
-                : internalParams.BufferSize;
-            var endOffset = startOffset + buffSize - 1;
-
-            internalParams.Headers["Content-Range"] = $"bytes {startOffset}-{endOffset}/{fileLength}";
         }
 
         private Task<T> CallUploadApiAsync<T>(
@@ -1006,33 +1102,12 @@ namespace CloudinaryDotNet
                 cancellationToken);
         }
 
-        private string GetUploadUrl(string resourceType)
-        {
-            return GetApiUrlV().Action(Constants.ACTION_NAME_UPLOAD).ResourceType(resourceType).BuildUrl();
-        }
-
         private string GetRenameUrl(RenameParams parameters) =>
             m_api
                 .ApiUrlImgUpV
                 .ResourceType(ApiShared.GetCloudinaryParam(parameters.ResourceType))
                 .Action("rename")
                 .BuildUrl();
-
-        private string CheckUploadParametersAndGetUploadUrl(BasicRawUploadParams parameters)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters), "Upload parameters should be defined");
-            }
-
-            string uri = GetApiUrlV()
-                .Action(Constants.ACTION_NAME_UPLOAD)
-                .ResourceType(ApiShared.GetCloudinaryParam(parameters.ResourceType))
-                .BuildUrl();
-
-            parameters.File.Reset();
-            return uri;
-        }
 
         /// <summary>
         /// Uploads a resource to Cloudinary.
@@ -1055,14 +1130,21 @@ namespace CloudinaryDotNet
         private Task<T> UploadAsync<T>(BasicRawUploadParams parameters, CancellationToken? cancellationToken = null)
             where T : UploadResult, new()
         {
-            var uri = CheckUploadParametersAndGetUploadUrl(parameters);
+            CheckUploadParameters(parameters);
+
+            parameters.File.Reset();
 
             return CallUploadApiAsync<T>(
                 HttpMethod.POST,
-                uri,
+                GetUploadUrl(parameters),
                 parameters,
                 cancellationToken,
                 null);
+        }
+
+        private string GetUploadUrl(BasicRawUploadParams parameters)
+        {
+            return m_api.GetUploadUrl(ApiShared.GetCloudinaryParam(parameters.ResourceType));
         }
 
         private string GetDownloadUrl(UrlBuilder builder, IDictionary<string, object> parameters)
@@ -1070,78 +1152,6 @@ namespace CloudinaryDotNet
             m_api.FinalizeUploadParameters(parameters);
             builder.SetParameters(parameters);
             return builder.ToEncodedString();
-        }
-
-        /// <summary>
-        /// Upload large file parameters.
-        /// </summary>
-        internal class UploadLargeParams
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="CloudinaryDotNet.Cloudinary.UploadLargeParams"/> class.
-            /// </summary>
-            /// <param name="parameters">Basic raw upload parameters.</param>
-            /// <param name="bufferSize">Buffer size.</param>
-            /// <param name="api">Technological layer to work with cloudinary API.</param>
-            public UploadLargeParams(BasicRawUploadParams parameters, int bufferSize, Api api)
-            {
-                parameters.File.Reset(bufferSize);
-                Parameters = parameters;
-                Url = GetUploadUrl(parameters, api);
-                BufferSize = bufferSize != 0 ? bufferSize : DEFAULT_CHUNK_SIZE;
-            }
-
-            /// <summary>
-            /// Gets buffer size.
-            /// </summary>
-            public int BufferSize { get; }
-
-            /// <summary>
-            /// Gets url.
-            /// </summary>
-            public string Url { get; }
-
-            /// <summary>
-            /// Gets basic raw upload parameters.
-            /// </summary>
-            public BasicRawUploadParams Parameters { get; }
-
-            /// <summary>
-            /// Gets request headers.
-            /// </summary>
-            public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>
-            {
-                ["X-Unique-Upload-Id"] = RandomPublicId(),
-            };
-
-            /// <summary>
-            /// Generate random PublicId.
-            /// </summary>
-            /// <returns>Randomly generated PublicId.</returns>
-            private static string RandomPublicId()
-            {
-                var buffer = new byte[8];
-                new Random().NextBytes(buffer);
-                return string.Concat(buffer.Select(x => x.ToString("X2", CultureInfo.InvariantCulture)).ToArray());
-            }
-
-            /// <summary>
-            /// A convenient method for uploading an image before testing.
-            /// </summary>
-            /// <param name="parameters">Parameters of type BasicRawUploadParams.</param>
-            /// <param name="mApi">Action to set custom upload parameters.</param>
-            /// <returns>The upload url.</returns>
-            private static string GetUploadUrl(BasicRawUploadParams parameters, Api mApi)
-            {
-                var url = mApi.ApiUrlImgUpV;
-                var name = Enum.GetName(typeof(ResourceType), parameters.ResourceType);
-                if (name != null)
-                {
-                    url.ResourceType(name.ToLowerInvariant());
-                }
-
-                return url.BuildUrl();
-            }
         }
     }
 }

--- a/CloudinaryDotNet/CloudinaryDotNet.csproj
+++ b/CloudinaryDotNet/CloudinaryDotNet.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>

--- a/CloudinaryDotNet/Core/ChunkData.cs
+++ b/CloudinaryDotNet/Core/ChunkData.cs
@@ -1,0 +1,57 @@
+namespace CloudinaryDotNet.Core
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Represents a chunk of data along with its start and end bytes, and total bytes.
+    /// </summary>
+    public class ChunkData
+    {
+        private bool lastChunk;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChunkData"/> class.
+        /// </summary>
+        /// <param name="chunk">The chunk of data as a stream.</param>
+        /// <param name="startByte">The index of the start byte in the original stream.</param>
+        /// <param name="endByte">The index of the end byte in the original stream.</param>
+        /// <param name="totalBytes">The total number of bytes in the original stream.</param>
+        public ChunkData(Stream chunk, long startByte, long endByte, long totalBytes)
+        {
+            Chunk = chunk ?? throw new ArgumentNullException(nameof(chunk));
+            StartByte = startByte;
+            EndByte = endByte;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// Gets or sets the chunk of data as a stream.
+        /// </summary>
+        public Stream Chunk { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the start byte in the original stream.
+        /// </summary>
+        public long StartByte { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the end byte in the original stream.
+        /// </summary>
+        public long EndByte { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of bytes in the original stream.
+        /// </summary>
+        public long TotalBytes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether current chunk is the last one.
+        /// </summary>
+        public bool LastChunk
+        {
+            get => lastChunk ? lastChunk : TotalBytes != -1 && TotalBytes == EndByte + 1;
+            set => lastChunk = value;
+        }
+    }
+}

--- a/CloudinaryDotNet/Core/LimitedStream.cs
+++ b/CloudinaryDotNet/Core/LimitedStream.cs
@@ -1,0 +1,87 @@
+namespace CloudinaryDotNet.Core
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Helper class for creating a limited view of the stream.
+    /// <inheritdoc />
+    /// </summary>
+    internal class LimitedStream : Stream
+    {
+        private readonly Stream originalStream;
+        private long remainingBytes;
+        private long startOffset;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LimitedStream"/> class.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="offset">The offset from which to start reading in the underlying stream.
+        ///                      We ignore it for non-seekable streams.</param>
+        /// <param name="maxBytes">Maximum bytes to read.</param>
+        public LimitedStream(Stream stream, long offset, long maxBytes)
+        {
+            originalStream = stream ?? throw new ArgumentNullException(nameof(stream));
+            remainingBytes = maxBytes;
+            startOffset = offset;
+
+            if (!stream.CanSeek)
+            {
+                return;
+            }
+
+            if (startOffset < 0 || startOffset >= originalStream.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startOffset), "Offset is out of range.");
+            }
+
+            remainingBytes = Math.Min(maxBytes, originalStream.Length - startOffset);
+
+            originalStream.Seek(startOffset, SeekOrigin.Begin);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => true;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => false;
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // make sure stream is not moved around.
+            originalStream.Seek(startOffset, SeekOrigin.Begin);
+
+            var bytesRead = originalStream.Read(buffer, offset, (int)Math.Min(count, remainingBytes));
+            remainingBytes -= bytesRead;
+
+            return bytesRead;
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/CloudinaryDotNet/Core/SystemExtension.cs
+++ b/CloudinaryDotNet/Core/SystemExtension.cs
@@ -1,0 +1,45 @@
+namespace CloudinaryDotNet.Core
+{
+    using System.Reflection;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// SystemExtension.
+    /// </summary>
+    public static class SystemExtension
+    {
+        /// <summary>
+        /// Clones the object.
+        /// </summary>
+        /// <param name="source">The source to clone.</param>
+        /// <typeparam name="T">Object type.</typeparam>
+        /// <returns>New instance of the cloned object.</returns>
+        public static T Clone<T>(this T source)
+        {
+            var serialized = JsonConvert.SerializeObject(source);
+            return JsonConvert.DeserializeObject<T>(serialized);
+        }
+
+        /// <summary>
+        /// Copies the writable properties from the source object to the destination object.
+        /// </summary>
+        /// <param name="source">The source object whose properties will be copied.</param>
+        /// <param name="destination">The destination object where the properties will be copied.</param>
+        public static void CopyPropertiesTo(this object source, object destination)
+        {
+            var properties = typeof(FileDescription).GetRuntimeProperties();
+
+            foreach (var property in properties)
+            {
+                if (!property.CanWrite)
+                {
+                    continue;
+                }
+
+                var value = property.GetValue(source);
+
+                property.SetValue(destination, value);
+            }
+        }
+    }
+}

--- a/CloudinaryDotNet/FileDescription.cs
+++ b/CloudinaryDotNet/FileDescription.cs
@@ -1,11 +1,21 @@
 ﻿namespace CloudinaryDotNet
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using CloudinaryDotNet.Core;
 
     /// <summary>
     /// Represents a file for uploading to cloudinary.
     /// </summary>
-    public class FileDescription
+    // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
+    [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope", Justification = "Reviewed.")]
+    public class FileDescription : IDisposable
     {
         /// <summary>
         /// Indicates whether the file/stream content represents the last chunk of a large file.
@@ -20,28 +30,45 @@
         /// <summary>
         /// Maximum size of a single chunk of data to be uploaded.
         /// </summary>
-        internal int BufferSize = int.MaxValue;
-
-        /// <summary>
-        /// Current position (offset) in file (full file).
-        /// </summary>
-        internal long CurrPos;
-
-        /// <summary>
-        /// Current position (offset) in the current chunk.
-        /// </summary>
-        internal long CurrChunkPos;
+        internal int BufferSize = UnlimitedBuffer;
 
         /// <summary>
         /// Current chunk size.
         /// </summary>
         internal long CurrChunkSize;
 
-        private bool isEof;
+        /// <summary>
+        /// Represents chunks of file for upload.
+        /// </summary>
+        protected BlockingCollection<ChunkData> chunks;
 
-        private Stream stream;
+        private const int UnlimitedBuffer = int.MaxValue;
+
+        private readonly Mutex mutex = new ();
+
+        private Stream fileStream;
 
         private string filePath;
+
+        private long currPos;
+
+        private bool disposedValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileDescription"/> class with default values.
+        /// </summary>
+        public FileDescription()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileDescription"/> class.
+        /// </summary>
+        /// <param name="original">The original object to copy from.</param>
+        public FileDescription(FileDescription original)
+        {
+            original.CopyPropertiesTo(this);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileDescription"/> class.
@@ -63,9 +90,21 @@
         /// <param name="filePath">Either URL (http/https/s3/data) or local path to file.</param>
         public FileDescription(string name, string filePath)
         {
-            IsRemote = Utils.IsRemoteFile(filePath);
             FilePath = filePath;
             FileName = IsRemote ? filePath : name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileDescription"/> class.
+        /// Constructor to upload file by path specifying explicit filename.
+        /// </summary>
+        /// <param name="name">Resource name.</param>
+        /// <param name="chunked">Indicates whether we want to use chunked upload and chunks will be passed.</param>
+        public FileDescription(string name, bool chunked = true)
+        {
+            FileName = name;
+            Chunked = chunked;
+            chunks = new BlockingCollection<ChunkData>();
         }
 
         /// <summary>
@@ -75,28 +114,27 @@
         /// <param name="filePath">Either URL (http/https/s3/data) or local path to file.</param>
         public FileDescription(string filePath)
         {
-            IsRemote = Utils.IsRemoteFile(filePath);
             FilePath = filePath;
-            FileName = IsRemote ? filePath : Path.GetFileName(filePath);
         }
 
         /// <summary>
         /// Gets or sets stream to upload.
         /// </summary>
-        public Stream Stream
-        {
-            get => stream;
-            set
-            {
-                stream = value;
-                CurrChunkPos = 0;
-            }
-        }
+        public Stream Stream { get; set; }
 
         /// <summary>
         /// Gets or sets name of the file to upload.
         /// </summary>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets current position (offset) in file (full file).
+        /// </summary>
+        public long CurrPos
+        {
+            get => currPos;
+            set => Interlocked.Exchange(ref currPos, value);
+        }
 
         /// <summary>
         /// Gets or sets filesystem path to the file to upload.
@@ -107,35 +145,240 @@
             set
             {
                 filePath = value;
-                CurrChunkPos = 0;
+                IsRemote = Utils.IsRemoteFile(filePath);
+                FileName = IsRemote ? filePath : Path.GetFileName(filePath);
+
+                Reset();
             }
         }
+
+        /// <summary>
+        /// Gets or sets file size.
+        /// </summary>
+        public long FileSize { get; set; } = -1;
 
         /// <summary>
         /// Gets a value indicating whether it is remote (by URL) or local file.
         /// </summary>
-        public bool IsRemote { get; }
+        public bool IsRemote { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the pointer is at the end of file.
+        /// Gets a value indicating whether the pointer is at the end of file.
         /// </summary>
-        internal bool Eof
+        internal bool Eof { get; private set; }
+
+        /// <summary>
+        /// Gets or creates a file stream( if applicable).
+        /// </summary>
+        /// <returns>File stream or null for remote or uploads from single chunks.</returns>
+        public Stream GetFileStream()
         {
-            get => isEof ? isEof : GetFileLength() != -1 && CurrPos == GetFileLength();
-            set => isEof = value;
+            if (Stream != null)
+            {
+                return Stream;
+            }
+            #if NETSTANDARD1_3
+            return fileStream ??= IsRemote || string.IsNullOrEmpty(FilePath) ? null : File.OpenRead(FilePath);
+            #else
+            return fileStream ??= IsRemote || string.IsNullOrEmpty(FilePath) ? null : Stream.Synchronized(File.OpenRead(FilePath));
+            #endif
         }
 
         /// <summary>
-        /// Get file length.
+        /// Adds a single chunk.
+        /// </summary>
+        /// <param name="chunkStream">The chunk content.</param>
+        /// <param name="last"> Indicates whether the chunk represents the last chunk of a large file.</param>
+        public void AddChunk(Stream chunkStream, bool last = false)
+        {
+            if (!chunkStream.CanSeek)
+            {
+                throw new NotSupportedException("Cannot add non-seekable streams without specifying their size. Use a different overload method.");
+            }
+
+            AddChunk(chunkStream, currPos, chunkStream.Length, last);
+        }
+
+        /// <summary>
+        /// Adds a single chunk.
+        /// </summary>
+        /// <param name="chunkPath">The chunk file path.</param>
+        /// <param name="last"> Indicates whether the chunk represents the last chunk of a large file.</param>
+        public void AddChunk(string chunkPath, bool last = false)
+        {
+            var chunkStream = File.Open(chunkPath, FileMode.Open);
+
+            AddChunk(chunkStream, last);
+        }
+
+        /// <summary>
+        /// Adds a single chunk.
+        /// </summary>
+        /// <param name="chunkPaths">A List of the file chunks paths.</param>
+        public void AddChunks(List<string> chunkPaths)
+        {
+            foreach (var chunkPath in chunkPaths)
+            {
+                AddChunk(chunkPath, chunkPaths.IndexOf(chunkPath) == chunkPaths.Count - 1);
+            }
+        }
+
+        /// <summary>
+        /// Adds a single chunk.
+        /// </summary>
+        /// <param name="chunkStreams">A List of the file chunks streams.</param>
+        public void AddChunks(List<Stream> chunkStreams)
+        {
+            foreach (var chunkStream in chunkStreams)
+            {
+                AddChunk(chunkStream, chunkStreams.IndexOf(chunkStream) == chunkStreams.Count - 1);
+            }
+        }
+
+        /// <summary>
+        /// Adds a single chunk.
+        /// </summary>
+        /// <param name="chunkStream">The chunk content.</param>
+        /// <param name="startByte">Chunk start offset.</param>
+        /// <param name="chunkSize">Chunk size.</param>
+        /// <param name="last"> Indicates whether the chunk represents the last chunk of a large file.</param>
+        public void AddChunk(Stream chunkStream, long startByte, long chunkSize, bool last = false)
+        {
+            chunks ??= new BlockingCollection<ChunkData>();
+
+            CurrPos = startByte + chunkSize;
+
+            if (last)
+            {
+                FileSize = CurrPos;
+            }
+
+            var limitedStream = new LimitedStream(chunkStream, 0, chunkSize);
+            var chunk = new ChunkData(limitedStream, startByte, CurrPos - 1, FileSize)
+            {
+                LastChunk = last,
+            };
+
+            chunks.Add(chunk);
+
+            if (last)
+            {
+                chunks.CompleteAdding();
+            }
+        }
+
+        /// <summary>
+        /// Gets a range from file asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>ChunkData class representing a single chunk.</returns>
+        public async Task<ChunkData> GetNextChunkAsync(CancellationToken? cancellationToken = null)
+        {
+            // lock this section, so we don't send the same chunk multiple times.
+            mutex.WaitOne();
+            try
+            {
+                Stream resultingStream;
+
+                var chunkStream = GetFileStream();
+
+                if (chunkStream == null)
+                {
+                    return TakeNextChunk();
+                }
+
+                if (chunkStream.CanSeek)
+                {
+                    // Create a limited stream over the stream and return it.
+                    CurrChunkSize = Math.Min(BufferSize, chunkStream.Length - CurrPos);
+                    resultingStream = new LimitedStream(chunkStream, CurrPos, CurrChunkSize);
+                    if (CurrChunkSize < BufferSize && BufferSize != UnlimitedBuffer)
+                    {
+                        LastChunk = true;
+                    }
+                }
+                else
+                {
+                    // We actually need to read data, otherwise we will not know the size of the chunk.
+                    resultingStream = new MemoryStream();
+                    using var writer = new StreamWriter(resultingStream, Encoding.ASCII, 1024, leaveOpen: true);
+                    writer.AutoFlush = true;
+
+                    CurrChunkSize = await ReadBytesAsync(chunkStream, writer, BufferSize, cancellationToken).ConfigureAwait(false);
+
+                    resultingStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                var chunk = new ChunkData(resultingStream, CurrPos, CurrPos + CurrChunkSize - 1, FileSize);
+
+                CurrPos += CurrChunkSize;
+
+                if ((BufferSize != UnlimitedBuffer && CurrChunkSize < BufferSize) || LastChunk)
+                {
+                    Eof = true;
+                    chunk.TotalBytes = FileSize = CurrPos;
+                }
+
+                return chunk;
+            }
+            finally
+            {
+                mutex.ReleaseMutex();
+            }
+        }
+
+        /// <summary>
+        /// Returns number of chunks in a large file.
+        /// </summary>
+        /// <returns>Number of file chunks.</returns>
+        public int GetNumOfChunks()
+        {
+            if (chunks != null && chunks.Count != 0)
+            {
+                return chunks.Count;
+            }
+
+            if (BufferSize is UnlimitedBuffer or 0)
+            {
+                return 1;
+            }
+
+            var fileLength = GetFileLength();
+
+            if (fileLength > 0)
+            {
+                return (int)Math.Ceiling((double)fileLength / BufferSize);
+            }
+
+            return -1;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Reset stream buffer length and bytes sent values.
+        /// </summary>
+        /// <param name="bufferSize">(Optional) Size of the buffer.</param>
+        internal void Reset(int bufferSize = UnlimitedBuffer)
+        {
+            BufferSize = bufferSize;
+            CurrPos = 0;
+            LastChunk = false;
+            fileStream?.Dispose();
+            fileStream = null;
+        }
+
+        /// <summary>
+        /// Gets file length.
         /// </summary>
         /// <returns>The length of file.</returns>
         internal long GetFileLength()
         {
-            if (Chunked)
-            {
-                return -1; // unknown length
-            }
-
             if (Stream == null)
             {
                 return new FileInfo(FilePath).Length;
@@ -150,25 +393,66 @@
         }
 
         /// <summary>
-        /// Reset stream buffer length and bytes sent values.
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting managed and unmanaged resources.
         /// </summary>
-        /// <param name="bufferSize">(Optional) Size of the buffer.</param>
-        internal void Reset(int bufferSize = int.MaxValue)
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
         {
-            BufferSize = bufferSize;
-            CurrPos = 0;
-            CurrChunkPos = 0;
-            LastChunk = false;
+            if (disposedValue)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                fileStream?.Dispose();
+                fileStream = null;
+
+                chunks?.Dispose();
+                chunks = null;
+
+                mutex.Dispose();
+            }
+
+            disposedValue = true;
+        }
+
+        private static async Task<int> ReadBytesAsync(Stream stream, StreamWriter writer, int bytes, CancellationToken? cancellationToken = null)
+        {
+            var bytesSent = 0;
+            var buf = new byte[65000];
+            int toSend;
+            int cnt;
+            var token = cancellationToken ?? CancellationToken.None;
+            while ((toSend = bytes - bytesSent) > 0
+                   && (cnt = await stream.ReadAsync(buf, 0, toSend > buf.Length ? buf.Length : toSend, token).ConfigureAwait(false)) > 0)
+            {
+                await writer.BaseStream.WriteAsync(buf, 0, cnt, token).ConfigureAwait(false);
+                bytesSent += cnt;
+            }
+
+            return bytesSent;
         }
 
         /// <summary>
-        /// Shift current position by an offset value.
+        /// Takes a single chunk.
         /// </summary>
-        /// <param name="offset">The offset to apply.</param>
-        internal void ShiftCurrPos(long offset)
+        private ChunkData TakeNextChunk()
         {
-            CurrPos += offset;
-            CurrChunkPos += offset;
+            if (!Chunked)
+            {
+                return null;
+            }
+
+            try
+            {
+                return chunks.Take();
+            }
+            catch (InvalidOperationException)
+            {
+                // An InvalidOperationException means that Take() was called on a completed collection
+                return null;
+            }
         }
     }
 }

--- a/CloudinaryDotNet/ICloudinaryAdminApi.cs
+++ b/CloudinaryDotNet/ICloudinaryAdminApi.cs
@@ -12,6 +12,19 @@ namespace CloudinaryDotNet
     public interface ICloudinaryAdminApi
     {
         /// <summary>
+        /// Tests the reachability of the Cloudinary API.
+        /// </summary>
+        /// <returns>Ping result.</returns>
+        PingResult Ping();
+
+        /// <summary>
+        /// Tests the reachability of the Cloudinary API asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Ping result.</returns>
+        Task<PingResult> PingAsync(CancellationToken? cancellationToken = null);
+
+        /// <summary>
         /// Create a new streaming profile asynchronously.
         /// </summary>
         /// <param name="parameters">Parameters of streaming profile creating.</param>

--- a/CloudinaryDotNet/ICloudinaryUploadApi.cs
+++ b/CloudinaryDotNet/ICloudinaryUploadApi.cs
@@ -224,6 +224,94 @@ namespace CloudinaryDotNet
         T UploadLarge<T>(BasicRawUploadParams parameters, int bufferSize = 0)
             where T : UploadResult, new();
 
+                /// <summary>
+        /// Uploads large resources to Cloudinary by dividing it to chunks asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type of result of upload.</typeparam>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="bufferSize">Chunk (buffer) size (20 MB by default).</param>
+        /// <param name="maxConcurrentUploads">Maximum number of concurrent uploads.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        Task<T> UploadLargeAsync<T>(
+            BasicRawUploadParams parameters,
+            int bufferSize = 0,
+            int maxConcurrentUploads = 1,
+            CancellationToken? cancellationToken = null)
+            where T : UploadResult, new();
+
+        /// <summary>
+        /// Uploads a single chunk of a file to Cloudinary asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type of result of upload.</typeparam>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        Task<T> UploadChunkAsync<T>(
+            BasicRawUploadParams parameters,
+            CancellationToken? cancellationToken = null)
+            where T : UploadResult, new();
+
+        /// <summary>
+        /// Uploads a single chunk of a raw file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        Task<RawUploadResult> UploadChunkAsync(
+            RawUploadParams parameters,
+            CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Uploads a single chunk of an image file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        Task<ImageUploadResult> UploadChunkAsync(
+            ImageUploadParams parameters,
+            CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Uploads a single chunk of a video file to Cloudinary asynchronously.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <param name="cancellationToken">(Optional) Cancellation token.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        Task<VideoUploadResult> UploadChunkAsync(
+            VideoUploadParams parameters,
+            CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Uploads a single chunk of a file to Cloudinary.
+        /// </summary>
+        /// <typeparam name="T">The type of result of upload.</typeparam>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        T UploadChunk<T>(BasicRawUploadParams parameters)
+            where T : UploadResult, new();
+
+        /// <summary>
+        /// Uploads a single chunk of a raw file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        RawUploadResult UploadChunk(RawUploadParams parameters);
+
+        /// <summary>
+        /// Uploads a single chunk of an image file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        ImageUploadResult UploadChunk(ImageUploadParams parameters);
+
+        /// <summary>
+        /// Uploads a single chunk of a video file to Cloudinary.
+        /// </summary>
+        /// <param name="parameters">Parameters of file uploading.</param>
+        /// <returns>Parsed result of uploading.</returns>
+        VideoUploadResult UploadChunk(VideoUploadParams parameters);
+
         /// <summary>
         /// Changes public identifier of a file asynchronously.
         /// </summary>

--- a/CloudinaryDotNet/Utils.cs
+++ b/CloudinaryDotNet/Utils.cs
@@ -6,7 +6,6 @@
     using System.Globalization;
     using System.Linq;
     using System.Linq.Expressions;
-    using System.Net;
     using System.Security.Cryptography;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -160,6 +159,17 @@
             }
 
             return signature.ToString();
+        }
+
+        /// <summary>
+        /// Generate random PublicId.
+        /// </summary>
+        /// <returns>Randomly generated PublicId.</returns>
+        internal static string RandomPublicId()
+        {
+            var buffer = new byte[8];
+            new Random().NextBytes(buffer);
+            return string.Concat(buffer.Select(x => x.ToString("X2", CultureInfo.InvariantCulture)).ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
### Brief Summary of Changes
This PR adds support for `UploadChunk` Upload API method. 

Users can use it to implement their own way of uploading chunks of large files to Cloudinary.

See unit tests for usage examples.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
