### PR TITLE
Fix mutex synchronization on GetNextChunk in FileDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+1.27.7 / 2025-08-25
+===================
+
+  * Fix async synchronization issue with `GetNextChunkAsync` in FileDescription 
+
 1.27.6 / 2025-06-17
 ===================
 

--- a/CloudinaryDotNet/CloudinaryDotNet.csproj
+++ b/CloudinaryDotNet/CloudinaryDotNet.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <RootNamespace>CloudinaryDotNet</RootNamespace>
     <Authors>Cloudinary</Authors>
-    <Version>1.27.6</Version>
+    <Version>1.27.7</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>Official client library for easily integrating with the Cloudinary service</Description>
     <PackageTags>Image Video Responsive Web Utility CDN Performance Resize Crop Rotate Quality Watermark Gif Jpg Jpeg Bitmap PNG Tiff Webp Webm mp4 avi Filter Effect</PackageTags>

--- a/CloudinaryDotNet/CloudinaryVersion.cs
+++ b/CloudinaryDotNet/CloudinaryVersion.cs
@@ -8,6 +8,6 @@ namespace CloudinaryDotNet
         /// <summary>
         /// Gets full version number of Cloudinary .NET SDK.
         /// </summary>
-        public static string Full => "1.27.6";
+        public static string Full => "1.27.7";
     }
 }

--- a/CloudinaryDotNet/FileDescription.cs
+++ b/CloudinaryDotNet/FileDescription.cs
@@ -44,7 +44,7 @@
 
         private const int UnlimitedBuffer = int.MaxValue;
 
-        private readonly Mutex mutex = new ();
+        private readonly SemaphoreSlim semaphoreSlim = new (1, 1);
 
         private readonly object chunkLock = new ();
 
@@ -290,7 +290,7 @@
         public async Task<ChunkData> GetNextChunkAsync(CancellationToken? cancellationToken = null)
         {
             // lock this section, so we don't send the same chunk multiple times.
-            mutex.WaitOne();
+            await semaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
                 Stream resultingStream;
@@ -338,7 +338,7 @@
             }
             finally
             {
-                mutex.ReleaseMutex();
+                semaphoreSlim.Release();
             }
         }
 
@@ -426,7 +426,7 @@
                 chunks?.Dispose();
                 chunks = null;
 
-                mutex.Dispose();
+                semaphoreSlim.Dispose();
             }
 
             disposedValue = true;


### PR DESCRIPTION
### Brief Summary of Changes
Resolve synchronization issue due to different Thread releasing the mutex.
Using `SemaphoreSlim` for async locking

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
