### PR TITLE
Fix `Authorization` header when no API credentials are configured

### DIFF
--- a/CloudinaryDotNet.Tests/ApiAuthorizationTest.cs
+++ b/CloudinaryDotNet.Tests/ApiAuthorizationTest.cs
@@ -103,6 +103,23 @@ namespace CloudinaryDotNet.Tests
             Assert.IsTrue(m_mockedCloudinary.HttpRequestContent.Contains("upload_preset"));
         }
 
+        [Test]
+        public async Task TestUnsignedUploadHasNoAuthorizationHeader()
+        {
+            InitCloudinaryApi(null, null);
+
+            var uploadParams = new ImageUploadParams()
+            {
+                File = new FileDescription(Path.GetTempFileName()),
+                Unsigned = true,
+                UploadPreset = "api_test_upload_preset"
+            };
+
+            await m_mockedCloudinary.UploadAsync(uploadParams);
+
+            Assert.IsNull(m_mockedCloudinary.HttpRequestHeaders.Authorization);
+        }
+
         private void InitCloudinaryApi()
         {
             m_mockedCloudinary = new MockedCloudinary(account: new Account(m_cloudName, m_oauthToken));

--- a/CloudinaryDotNet/ApiShared.Internal.cs
+++ b/CloudinaryDotNet/ApiShared.Internal.cs
@@ -432,9 +432,22 @@
 
         private AuthenticationHeaderValue GetAuthorizationHeaderValue()
         {
-            return !string.IsNullOrEmpty(Account.OAuthToken)
-                ? new AuthenticationHeaderValue("Bearer", Account.OAuthToken)
-                : new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(GetApiCredentials())));
+            if (!string.IsNullOrEmpty(Account.OAuthToken))
+            {
+                return new AuthenticationHeaderValue("Bearer", Account.OAuthToken);
+            }
+
+            // Skip the Authorization header when no credentials are configured
+            // (e.g. unsigned uploads created with an Account that has no key/secret).
+            var credentials = GetApiCredentials();
+            if (string.IsNullOrEmpty(credentials) || credentials == ":")
+            {
+                return null;
+            }
+
+            return new AuthenticationHeaderValue(
+                "Basic",
+                Convert.ToBase64String(Encoding.ASCII.GetBytes(credentials)));
         }
 
         private void SetRequestHeaders(
@@ -448,7 +461,10 @@
                 : string.Format(CultureInfo.InvariantCulture, "{0} {1}", UserPlatform, USER_AGENT);
             request.Headers.Add("User-Agent", userPlatform);
 
-            request.Headers.Authorization = GetAuthorizationHeaderValue();
+            if (GetAuthorizationHeaderValue() is { } authorization)
+            {
+                request.Headers.Authorization = authorization;
+            }
 
             if (headers == null)
             {


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
