### PR TITLE
Add `CustomId` and `ExternalId` to `IdentityInfo`

### DIFF
--- a/CloudinaryDotNet.IntegrationTests/SearchApi/SearchApiTest.cs
+++ b/CloudinaryDotNet.IntegrationTests/SearchApi/SearchApiTest.cs
@@ -142,7 +142,9 @@ namespace CloudinaryDotNet.IntegrationTests.SearchApi
             Assert.Null(result.Resources[0].AccessControl);
             Assert.NotNull(result.Resources[0].Etag);
             Assert.NotNull(result.Resources[0].UploadedBy);
+            Assert.IsNotEmpty(result.Resources[0].UploadedBy.AccessKey);
             Assert.NotNull(result.Resources[0].CreatedBy);
+            Assert.IsNotEmpty(result.Resources[0].CreatedBy.AccessKey);
         }
 
         [Test, RetryWithDelay]

--- a/CloudinaryDotNet.Tests/SearchApi/SearchTest.cs
+++ b/CloudinaryDotNet.Tests/SearchApi/SearchTest.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using CloudinaryDotNet.Actions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -103,6 +105,86 @@ namespace CloudinaryDotNet.Tests.SearchApi
                 .Execute();
 
             AssertCorrectRequest(_cloudinary.HttpRequestContent);
+        }
+
+        [Test]
+        public void TestCreatedByAllFieldsDeserialize()
+        {
+            const string accessKey  = "123456789012345";
+            const string customId   = "user@example.com";
+            const string externalId = "abc123def456ghi789jkl012mno345";
+
+            var responseJson = JsonConvert.SerializeObject(new
+            {
+                total_count = 1,
+                time = 24,
+                resources = new[]
+                {
+                    new
+                    {
+                        asset_id     = "aabbccddeeff00112233445566778899",
+                        public_id    = "sample_user_upload",
+                        resource_type = "image",
+                        type         = "upload",
+                        created_at   = "2026-05-10T12:40:00+00:00",
+                        status       = "active",
+                        created_by   = new { access_key = accessKey, custom_id = customId,  external_id = externalId },
+                        uploaded_by  = new { access_key = accessKey, custom_id = customId,  external_id = externalId },
+                    }
+                }
+            });
+
+            var cloudinary = new MockedCloudinary(responseJson);
+            var result = cloudinary.Search().Execute();
+
+            Assert.AreEqual(1, result.Resources.Count);
+            var resource = result.Resources.First();
+
+            Assert.IsNotNull(resource.CreatedBy,  "CreatedBy should not be null");
+            Assert.AreEqual(accessKey,  resource.CreatedBy.AccessKey);
+            Assert.AreEqual(customId,   resource.CreatedBy.CustomId);
+            Assert.AreEqual(externalId, resource.CreatedBy.ExternalId);
+
+            Assert.IsNotNull(resource.UploadedBy,  "UploadedBy should not be null");
+            Assert.AreEqual(accessKey,  resource.UploadedBy.AccessKey);
+            Assert.AreEqual(customId,   resource.UploadedBy.CustomId);
+            Assert.AreEqual(externalId, resource.UploadedBy.ExternalId);
+        }
+
+        [Test]
+        public void TestCreatedByAccessKeyOnlyDeserializes()
+        {
+            const string accessKey = "987654321098765";
+
+            var responseJson = JsonConvert.SerializeObject(new
+            {
+                total_count = 1,
+                time = 10,
+                resources = new[]
+                {
+                    new
+                    {
+                        asset_id      = "ffeeddccbbaa99887766554433221100",
+                        public_id     = "sample_api_key_upload",
+                        resource_type = "image",
+                        type          = "upload",
+                        created_at    = "2026-05-05T01:12:51+00:00",
+                        status        = "active",
+                        created_by    = new { access_key = accessKey },
+                        uploaded_by   = new { access_key = accessKey },
+                    }
+                }
+            });
+
+            var cloudinary = new MockedCloudinary(responseJson);
+            var result = cloudinary.Search().Execute();
+
+            var resource = result.Resources.First();
+
+            Assert.IsNotNull(resource.CreatedBy);
+            Assert.AreEqual(accessKey, resource.CreatedBy.AccessKey);
+            Assert.IsNull(resource.CreatedBy.CustomId,   "CustomId should be null for API-key uploads");
+            Assert.IsNull(resource.CreatedBy.ExternalId, "ExternalId should be null for API-key uploads");
         }
 
         private static void AssertCorrectRequest(string request)

--- a/CloudinaryDotNet/Actions/Search/IdentityInfo.cs
+++ b/CloudinaryDotNet/Actions/Search/IdentityInfo.cs
@@ -3,7 +3,7 @@
     using System.Runtime.Serialization;
 
     /// <summary>
-    /// Represents indetity data.
+    /// Represents identity data of the user who created or uploaded an asset.
     /// </summary>
     [DataContract]
     public class IdentityInfo
@@ -13,5 +13,17 @@
         /// </summary>
         [DataMember(Name = "access_key")]
         public string AccessKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom identifier of the user (e.g. email address).
+        /// </summary>
+        [DataMember(Name = "custom_id")]
+        public string CustomId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the external identifier of the user.
+        /// </summary>
+        [DataMember(Name = "external_id")]
+        public string ExternalId { get; set; }
     }
 }


### PR DESCRIPTION
The Search API returns `created_by`/`uploaded_by` with three fields — `access_key`, `custom_id`, and `external_id` — for assets uploaded by named users via the Cloudinary console. Only `access_key` was previously deserialized; `custom_id` (e.g. user email) and `external_id` were silently dropped.

### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
